### PR TITLE
Added Postgres compatibility

### DIFF
--- a/src/HasSlug.php
+++ b/src/HasSlug.php
@@ -85,7 +85,7 @@ trait HasSlug
     protected function otherRecordExistsWithSlug(string $slug) : bool
     {
         return (bool) static::where($this->slugOptions->slugField, $slug)
-            ->where($this->getKeyName(), '!=', $this->getKey() ?? '')
+            ->where($this->getKeyName(), '!=', $this->getKey() ?? '0')
             ->first();
     }
 


### PR DESCRIPTION
On an app running Postgres I was getting the following  error:

```
SQLSTATE[22P02]: Invalid text representation: 7 ERROR:  invalid input syntax for integer: ""
```

This commit fixes that.