### PR TITLE
Allow overwrites when updating the slug field

### DIFF
--- a/src/HasSlug.php
+++ b/src/HasSlug.php
@@ -39,13 +39,13 @@ trait HasSlug
 
         $this->guardAgainstInvalidSlugOptions();
 
-        $slug = str_slug($this->getSlugSourceString());
+        $slugField = $this->slugOptions->slugField;
+
+        $slug = $this->getOriginal($slugField) != $this->$slugField ? $this->$slugField : str_slug($this->getSlugSourceString());
 
         if ($this->slugOptions->generateUniqueSlugs) {
             $slug = $this->makeSlugUnique($slug);
         }
-
-        $slugField = $this->slugOptions->slugField;
 
         $this->$slugField = $slug;
     }

--- a/tests/Integration/HasSlugTest.php
+++ b/tests/Integration/HasSlugTest.php
@@ -138,4 +138,31 @@ class HasSlugTest extends TestCase
             ['a/ ', 'a'],
         ];
     }
+
+    /**
+     * @test
+     */
+    public function it_can_handle_overwrites_when_updating_a_model()
+    {
+        $model = TestModel::create(['name' => 'this is a test']);
+
+        $model->url = 'this-is-an-url';
+        $model->save();
+
+        $this->assertEquals('this-is-an-url', $model->url);
+    }
+
+    /**
+     * @test
+     */
+    public function it_can_handle_duplicates_when_overwriting_a_slug()
+    {
+        $model = TestModel::create(['name' => 'this is a test']);
+        $other_model = TestModel::create(['name' => 'this is an other']);
+
+        $model->url = 'this-is-an-other';
+        $model->save();
+
+        $this->assertEquals('this-is-an-other-1', $model->url);
+    }
 }


### PR DESCRIPTION
When the slug field is overwritten, the slug won't be generated from the source. The unicity check of the slug will still be made.