### PR TITLE
[feature] Add migrate command to auto generate migration for `slug` columns

### DIFF
--- a/src/MigrationCreator.php
+++ b/src/MigrationCreator.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace Spatie\Sluggable;
+
+class MigrationCreator extends \Illuminate\Database\Migrations\MigrationCreator
+{
+    /**
+     * Get the migration stub file.
+     *
+     * @param  string  $table
+     * @param  bool    $create
+     * @return string
+     */
+    protected function getStub($t, $c)
+    {
+        return $this->files->get(__DIR__.'/migration.stub');
+    }
+
+    /**
+     * Populate the place-holders in the migration stub.
+     *
+     * @param  string  $name
+     * @param  string  $stub
+     * @param  \Illuminate\Support\Collection|array  $migrations
+     * @return string
+     */
+    protected function populateStub($name, $stub, $migrations)
+    {
+        $stub = str_replace('DummyClass', $this->getClassName($name), $stub);
+
+        $up = collect($migrations)->map(function ($migration) {
+            return <<<UP
+        Schema::table('{$migration['table']}', function (Blueprint \$table) {
+            \$table->string('{$migration['column']}', {$migration['length']})->nullable();
+        });
+UP;
+        })->implode(PHP_EOL);
+
+        $down = collect($migrations)->map(function ($migration) {
+            return <<<DOWN
+        Schema::table('{$migration['table']}', function (Blueprint \$table) {
+            \$table->dropColumn('{$migration['column']}');
+        });
+DOWN;
+        })->implode(PHP_EOL);
+
+        return str_replace(['up_placeholder', 'down_placeholder'], [$up, $down], $stub);
+    }
+}

--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace Spatie\Sluggable;
+
+use Illuminate\Support\Composer;
+
+class ServiceProvider extends \Illuminate\Support\ServiceProvider
+{
+    /**
+     * Indicates if loading of the provider is deferred.
+     *
+     * @var bool
+     */
+    protected $defer = true;
+
+    /**
+     * Register the service provider.
+     *
+     * @return void
+     */
+    public function register()
+    {
+        $this->app->singleton('sluggable.migrate', function ($app) {
+            return new SlugThemAll(
+                $app[MigrationCreator::class],
+                $app['migrator'],
+                $app['composer']
+            );
+        });
+
+        $this->commands('sluggable.migrate');
+    }
+
+    /**
+     * Get the services provided by the provider.
+     *
+     * @return array
+     */
+    public function provides()
+    {
+        return ['sluggable.migrate'];
+    }
+}

--- a/src/SlugThemAll.php
+++ b/src/SlugThemAll.php
@@ -1,0 +1,140 @@
+<?php
+
+namespace Spatie\Sluggable;
+
+use Throwable;
+use Illuminate\Console\Command;
+use Illuminate\Support\Composer;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Migrations\Migrator;
+
+class SlugThemAll extends Command
+{
+    /** @var string */
+    protected $signature = 'slug-them:all';
+
+    /** @var string */
+    protected $description = "Slug'em all, them models";
+
+    /** @var \App\MigrationCreator */
+    protected $creator;
+
+    /** @var \Illuminate\Database\Migrations\Migrator */
+    protected $migrator;
+
+    /** @var \Illuminate\Support\Composer */
+    protected $composer;
+
+    public function __construct(MigrationCreator $creator, Migrator $migrator, Composer $composer)
+    {
+        parent::__construct();
+        $this->creator = $creator;
+        $this->migrator = $migrator;
+        $this->composer = $composer;
+    }
+
+    /**
+     * @todo - add option for paths/namespaces (filename) to check for the models
+     * @todo - add option for auto generating slugs for all the migrated tables
+     */
+    public function handle()
+    {
+        $migrations = $this->collectClasses()
+                           ->map([$this, 'filterSluggable'])->filter()
+                           ->map([$this, 'rejectExistingColumns'])->filter()
+                           ->each(function ($migration) {
+                               $this->line(
+                                   "<info>Adding</info> {$migration['column']} "
+                                  ."<info>column to</info> {$migration['table']} <info>table</info>"
+                               );
+                           });
+
+        if ($migrations->isEmpty()) {
+            $this->info('Nothing to migrate');
+            return;
+        }
+
+        $file = $this->create($migrations);
+        $this->line("<info>Migration created: </info>{$file}");
+
+        $this->composer->dumpAutoloads();
+
+        $this->migrator->runMigrationList([$file]);
+        $this->line("<info>Migrated: </info>{$file}");
+    }
+
+    /**
+     * Find all them classes in app/ & app/Models.
+     *
+     * @return \Illuminate\Support\Collection
+     */
+    protected function collectClasses()
+    {
+        return collect(
+            array_merge(glob(app_path('*.php')), glob(app_path('Models'.DIRECTORY_SEPARATOR.'*.php')))
+        )->map(function ($file) {
+            $file = str_replace([base_path(), '.php'], '', $file);
+            return str_replace(
+                'app\\',
+                app()->getNamespace(),
+                str_replace(DIRECTORY_SEPARATOR, '\\', $file)
+            );
+        });
+    }
+
+    /**
+     * Filter only HasSlug trait holders.
+     *
+     * @param  string $class
+     * @return \Illuminate\Database\Eloquent\Model|null
+     */
+    public  function filterSluggable($class)
+    {
+        try {
+            $instance = new $class;
+            if ($instance instanceof Model && in_array(HasSlug::class, class_uses($instance))) {
+                return $instance;
+            }
+        } catch (Throwable $e) {
+            //
+        }
+    }
+
+    /**
+     * Get SlugOptions and learn what the slug column name, aye?
+     * Then do the all-fired job to check column's existence.
+     *
+     * @param  \Illuminate\Database\Eloquent\Model $sluggable
+     * @return array|null
+     */
+    public function rejectExistingColumns($sluggable)
+    {
+        $table = $sluggable->getTable();
+        $column = $sluggable->getSlugOptions()->slugField;
+        $length = $sluggable->getSlugOptions()->maximumLength;
+        $schema = $sluggable->getConnection()->getSchemaBuilder()->getColumnListing($table);
+
+        if (!in_array($column, $schema)) {
+            return compact('table', 'column', 'length');
+        }
+    }
+
+    /**
+     * Create the migration file.
+     *
+     * @param  \Illuminate\Support\Collection $columns
+     * @return string
+     */
+    protected function create($columns)
+    {
+        $path = $this->creator->create(
+            'add_slug_columns_'.time(),
+            database_path(DIRECTORY_SEPARATOR.'migrations'),
+            $columns
+        );
+
+        require($path);
+
+        return pathinfo($path, PATHINFO_FILENAME);
+    }
+}

--- a/src/migration.stub
+++ b/src/migration.stub
@@ -1,0 +1,27 @@
+<?php
+
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+class DummyClass extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+up_placeholder
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+down_placeholder
+    }
+}


### PR DESCRIPTION
NOTE: this was a quick tinkering and, while fully functional and reliable, it still has a few `todos` - read, review and get back to me with your thoughts. Also the naming and code comments are somewhat comic and files are just dropped to `src/` ;)

- [x] collect models using `HasRole` trait
- [x] create and run migration adding _slug_ fields to appropriate tables
- [ ] allow customization with command options (models path, migrations path?)
- [ ] make running migration optional
- [ ] optional db query for auto-generating slugs for each table
- [ ] add tests (basically all the actions are handled by already tested laravel stuff, it's more of a formality)

This PR provides enhancement to the package integration process, so you can do this:

1. require package
2. use `HasRole` trait and configure `SlugOptions` in all the models you need
3. register `ServiceProvider` in `config/app.php`
4. *run `the command` that will*:
   - grab all the `Sluggable` models (from `app/` and `app/Models` currently)
   - pick models' tables that don't contain the _slug_ column yet
   - create a single migration file that will create all the appropriate _slug_ columns
   - run the migration

et voilà!

This way whenever you pull the package for an existing project with possibly numerous models, you don't have to waste time on manually crafting appropriate migrations.

![screenshot from 2016-05-29 18 38 53](https://cloud.githubusercontent.com/assets/6928818/15632682/0090f92c-25cd-11e6-8ee8-ae3c186863e4.png)


and here's the migration file:

```php
<?php

use Illuminate\Database\Schema\Blueprint;
use Illuminate\Database\Migrations\Migration;

class AddSlugColumns1464517548 extends Migration
{
    /**
     * Run the migrations.
     *
     * @return void
     */
    public function up()
    {
        Schema::table('articles', function (Blueprint $table) {
            $table->string('url', 255)->nullable();
        });
        Schema::table('districts', function (Blueprint $table) {
            $table->string('slug', 100)->nullable();
        });
        Schema::table('users', function (Blueprint $table) {
            $table->string('username', 20)->nullable();
        });
    }

    /**
     * Reverse the migrations.
     *
     * @return void
     */
    public function down()
    {
        Schema::table('articles', function (Blueprint $table) {
            $table->dropColumn('url');
        });
        Schema::table('districts', function (Blueprint $table) {
            $table->dropColumn('slug');
        });
        Schema::table('users', function (Blueprint $table) {
            $table->dropColumn('username');
        });
    }
}
```