### PR TITLE
Add options to manage slug processing events

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,6 +121,32 @@ $model->name = 'changed name';
 $model->save(); //url stays "my name"
 ```
 
+If you don't want to create the slug when the model is initially created you can set use the doNotGenerateSlugOnCreate() flag the slug options.
+
+```php
+public function getSlugOptions() : SlugOptions
+{
+    return SlugOptions::create()
+        ->generateSlugsFrom('name')
+        ->saveSlugsTo('url')
+        ->doNotGenerateSlugOnCreate()
+}
+```
+
+Similarly, if you want to prevent the slug from being updated on model updates, call doNotGenerateSlugOnUpdate(). This can be helpful for creating permalinks that don't change until you explicitly want it to.
+
+```php
+public function getSlugOptions() : SlugOptions
+{
+    return SlugOptions::create()
+        ->generateSlugsFrom('name')
+        ->saveSlugsTo('url')
+        ->doNotGenerateSlugOnUpdate()
+}
+```
+
+If you want to explicitly update the slug on the model you can call `generateSlug()` on your model at any time to make the slug according to your other options. Don't forget to `save()` the model to persist the update to your database.
+
 ## Change log
 
 Please see [CHANGELOG](CHANGELOG.md) for more information what has changed recently.

--- a/src/HasSlug.php
+++ b/src/HasSlug.php
@@ -20,12 +20,50 @@ trait HasSlug
     protected static function bootHasSlug()
     {
         static::creating(function (Model $model) {
-            $model->addSlug();
+            $model->generateSlugOnCreate();
         });
 
         static::updating(function (Model $model) {
-            $model->addSlug();
+            $model->generateSlugOnUpdate();
         });
+    }
+
+    /**
+     * Handle adding slug on model creation
+     */
+    protected function generateSlugOnCreate()
+    {
+        $this->slugOptions = $this->getSlugOptions();
+
+        if (!$this->slugOptions->generateSlugOnCreate) {
+            return;
+        }
+
+        $this->addSlug();
+    }
+
+    /**
+     * Handle adding slug on model update
+     */
+    protected function generateSlugOnUpdate()
+    {
+        $this->slugOptions = $this->getSlugOptions();
+
+        if (!$this->slugOptions->generateSlugOnUpdate) {
+            return;
+        }
+
+        $this->addSlug();
+    }
+
+    /**
+     * Handle setting slug on explicit request
+     */
+    public function generateSlug()
+    {
+        $this->slugOptions = $this->getSlugOptions();
+
+        $this->addSlug();
     }
 
     /**
@@ -33,8 +71,6 @@ trait HasSlug
      */
     protected function addSlug()
     {
-        $this->slugOptions = $this->getSlugOptions();
-
         $this->guardAgainstInvalidSlugOptions();
 
         $slug = $this->generateNonUniqueSlug();

--- a/src/SlugOptions.php
+++ b/src/SlugOptions.php
@@ -16,6 +16,12 @@ class SlugOptions
     /** @var int */
     public $maximumLength = 250;
 
+    /** @var bool */
+    public $generateSlugOnCreate = true;
+
+    /** @var bool */
+    public $generateSlugOnUpdate = true;
+
     public static function create(): SlugOptions
     {
         return new static();
@@ -50,6 +56,20 @@ class SlugOptions
     public function slugsShouldBeNoLongerThan(int $maximumLength): SlugOptions
     {
         $this->maximumLength = $maximumLength;
+
+        return $this;
+    }
+
+    public function doNotGenerateSlugOnCreate(): SlugOptions
+    {
+        $this->generateSlugOnCreate = false;
+
+        return $this;
+    }
+
+    public function doNotGenerateSlugOnUpdate(): SlugOptions
+    {
+        $this->generateSlugOnUpdate = false;
 
         return $this;
     }

--- a/tests/Integration/HasSlugTest.php
+++ b/tests/Integration/HasSlugTest.php
@@ -182,4 +182,56 @@ class HasSlugTest extends TestCase
 
         $this->assertEquals('this-is-an-other-1', $model->url);
     }
+
+    /** @test */
+    public function it_doesnt_create_the_slug_if_onCreate_is_false()
+    {
+        $model = new class extends TestModel {
+            public function getSlugOptions(): SlugOptions
+            {
+                return parent::getSlugOptions()->doNotGenerateSlugOnCreate();
+            }
+        };
+
+        $model->name = 'this is a test';
+        $model->save();
+
+        $this->assertEquals(null, $model->url);
+    }
+
+    /** @test */
+    public function it_doesnt_update_the_slug_if_onUpdate_is_false()
+    {
+        $model = new class extends TestModel {
+            public function getSlugOptions(): SlugOptions
+            {
+                return parent::getSlugOptions()->doNotGenerateSlugOnUpdate();
+            }
+        };
+
+        $model->name = 'this is a test';
+        $model->save();
+
+        $model->name = 'this is another test';
+        $model->save();
+
+        $this->assertEquals('this-is-a-test', $model->url);
+    }
+
+    /** @test */
+    public function it_allows_explicit_requests_to_update_slug()
+    {
+        $model = new class extends TestModel {
+            public function getSlugOptions(): SlugOptions
+            {
+                return parent::getSlugOptions()->doNotGenerateSlugOnCreate()->doNotGenerateSlugOnUpdate();
+            }
+        };
+
+        $model->name = 'this is a test';
+        $model->generateSlug();
+        $model->save();
+
+        $this->assertEquals('this-is-a-test', $model->url);
+    }
 }


### PR DESCRIPTION
The onCreate() and onUpdate() slug options are used to permit, or prevent slug
creation/update on model save. By default both are set to true which means there
is no change in the existing functionality.

Setting onUpdate(false) will prevent a new slug from being calculated and
overwrite the existing slug. This is very useful for creating permanent slugs
which do not automatically change once their created even if the field the slug
was generated from changes (think permalinks created based on blog titles).

Setting onCreate(false) will prevent a slug from being calculated and saved
to the model on creation. This may be useful to prevent creating slugs for some
models until some time after the creation (think again of permalinks not
created until a blog article is actually published).