### PR TITLE
fix: add withoutGlobalScopes to otherRecordExistsWithSlug 

### DIFF
--- a/src/HasSlug.php
+++ b/src/HasSlug.php
@@ -150,6 +150,7 @@ trait HasSlug
     {
         return (bool) static::where($this->slugOptions->slugField, $slug)
             ->where($this->getKeyName(), '!=', $this->getKey() ?? '0')
+            ->withoutGlobalScopes()
             ->first();
     }
 


### PR DESCRIPTION
Add withoutGlobalScopes to otherRecordExistsWithSlug  to avoid global scopes like soft deletes or other custom global scopes from keeping the slugs unique.