### PR TITLE
[LaraPackagePort] Analyse for Laravel 5.5

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,15 +16,14 @@
         }
     ],
     "require": {
-        "php" : ">=7.0.0",
-        "illuminate/database": "~5.0.0|~5.1.0|~5.2.0|~5.3.0|~5.4.0",
-        "illuminate/support": "~5.0.0|~5.1.0|~5.2.0|~5.3.0|~5.4.0"
-
+        "php": ">=7.0.0",
+        "illuminate/database": "~5.0.0|~5.1.0|~5.2.0|~5.3.0|~5.4.0|~5.5.x-dev",
+        "illuminate/support": "~5.0.0|~5.1.0|~5.2.0|~5.3.0|~5.4.0|~5.5.x-dev"
     },
     "require-dev": {
-        "orchestra/testbench": "~3.2.0|~3.3.0|~3.4.0@dev",
-        "orchestra/database": "~3.2.0|~3.3.0|~3.4.0@dev",
-        "phpunit/phpunit": "^5.0"
+        "orchestra/testbench": "~3.2.0|~3.3.0|~3.4.0@dev|~3.5.x-dev",
+        "orchestra/database": "~3.2.0|~3.3.0|~3.4.0@dev|~3.5.x-dev",
+        "phpunit/phpunit": "^6.2"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -17,12 +17,12 @@
     ],
     "require": {
         "php": ">=7.0.0",
-        "illuminate/database": "~5.0.0|~5.1.0|~5.2.0|~5.3.0|~5.4.0|~5.5.x-dev",
-        "illuminate/support": "~5.0.0|~5.1.0|~5.2.0|~5.3.0|~5.4.0|~5.5.x-dev"
+        "illuminate/database": "~5.0.0|~5.1.0|~5.2.0|~5.3.0|~5.4.0|~5.5.x-dev|~5.5.x-dev",
+        "illuminate/support": "~5.0.0|~5.1.0|~5.2.0|~5.3.0|~5.4.0|~5.5.x-dev|~5.5.x-dev"
     },
     "require-dev": {
-        "orchestra/testbench": "~3.2.0|~3.3.0|~3.4.0@dev|~3.5.x-dev",
-        "orchestra/database": "~3.2.0|~3.3.0|~3.4.0@dev|~3.5.x-dev",
+        "orchestra/testbench": "~3.2.0|~3.3.0|~3.4.0@dev|~3.5.x-dev|~3.5.x-dev",
+        "orchestra/database": "~3.2.0|~3.3.0|~3.4.0@dev|~3.5.x-dev|~3.5.x-dev",
         "phpunit/phpunit": "^6.2"
     },
     "autoload": {
@@ -39,3 +39,4 @@
         "test": "phpunit"
     }
 }
+


### PR DESCRIPTION
This Pull-Requests help you to prepare your Package for Laravel 5.5. I've tested it automated and this was the PHPUnit Result:
PHPUnit 6.3-dev by Sebastian Bergmann and contributors.

Runtime:       PHP 7.1.7 with Xdebug 2.5.5
Configuration: /Users/lukaskammerling/Code/OSS/spatieLaravelphp5.5/storage/spatie.laravel-sluggable/phpunit.xml.dist

.....................                                             21 / 21 (100%)

Time: 4.86 seconds, Memory: 12.00MB

OK (21 tests, 48 assertions)

Generating code coverage report in Clover XML format ... done

Generating code coverage report in HTML format ... done

Nice looks really good! There are no Errors so it might work in Laravel 5.5 without any adjustments