### PR TITLE
Added $slugLanguage option

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,6 +121,18 @@ public function getSlugOptions() : SlugOptions
 }
 ```
 
+To set the language used by `str_slug` you may call `usingLanguage`
+
+```php
+public function getSlugOptions() : SlugOptions
+{
+    return SlugOptions::create()
+        ->generateSlugsFrom('name')
+        ->saveSlugsTo('slug')
+        ->usingLanguage('nl');
+}
+```
+
 The slug may be slightly longer than the value specified, due to the suffix which is added to make it unique.
 
 You can also override the generated slug just by setting it to another value then the generated slug.

--- a/src/HasSlug.php
+++ b/src/HasSlug.php
@@ -95,7 +95,7 @@ trait HasSlug
             return $this->$slugField;
         }
 
-        return str_slug($this->getSlugSourceString(), $this->slugOptions->slugSeparator);
+        return str_slug($this->getSlugSourceString(), $this->slugOptions->slugSeparator, $this->slugOptions->slugLanguage);
     }
 
     /**

--- a/src/SlugOptions.php
+++ b/src/SlugOptions.php
@@ -90,4 +90,11 @@ class SlugOptions
 
         return $this;
     }
+
+    public function usingLanguage(string $language): SlugOptions
+    {
+        $this->slugLanguage = $language;
+
+        return $this;
+    }
 }

--- a/src/SlugOptions.php
+++ b/src/SlugOptions.php
@@ -24,6 +24,9 @@ class SlugOptions
 
     /** @var string */
     public $slugSeparator = '-';
+    
+    /** @var string */
+    public $slugLanguage = 'en';
 
     public static function create(): SlugOptions
     {

--- a/tests/Integration/HasSlugTest.php
+++ b/tests/Integration/HasSlugTest.php
@@ -236,13 +236,10 @@ class HasSlugTest extends TestCase
         $model = new class extends TestModel {
             public function getSlugOptions(): SlugOptions
             {
-                return parent::getSlugOptions()->usingLanguage('ar');
+                return parent::getSlugOptions()->usingLanguage('nl');
             }
         };
 
-        $model->name = 'أحمد محمد';
-        $model->save();
-
-        $this->assertEquals('أحمد-محمد', $model->url);
+        $this->assertEquals('nl', $model->getSlugOptions()->slugLanguage);
     }
 }

--- a/tests/Integration/HasSlugTest.php
+++ b/tests/Integration/HasSlugTest.php
@@ -229,4 +229,20 @@ class HasSlugTest extends TestCase
 
         $this->assertEquals('this_is_a_separator_test', $model->url);
     }
+
+    /** @test */
+    public function it_will_use_language_option_for_slug_generation()
+    {
+        $model = new class extends TestModel {
+            public function getSlugOptions(): SlugOptions
+            {
+                return parent::getSlugOptions()->usingLanguage('ar');
+            }
+        };
+
+        $model->name = 'أحمد محمد';
+        $model->save();
+
+        $this->assertEquals('أحمد-محمد', $model->url);
+    }
 }

--- a/tests/Integration/HasSlugTest.php
+++ b/tests/Integration/HasSlugTest.php
@@ -242,4 +242,19 @@ class HasSlugTest extends TestCase
 
         $this->assertEquals('nl', $model->getSlugOptions()->slugLanguage);
     }
+
+    /** @test */
+    public function it_can_generate_language_specific_slugs()
+    {
+        $model = new class extends TestModel {
+            public function getSlugOptions(): SlugOptions
+            {
+                return parent::getSlugOptions()->usingLanguage('ae');
+            }
+        };
+
+        $model->name = 'أحمد محمد';
+        $model->save();
+        $this->assertEquals('أحمد-محمد', $model->url);
+    }
 }

--- a/tests/Integration/HasSlugTest.php
+++ b/tests/Integration/HasSlugTest.php
@@ -249,12 +249,12 @@ class HasSlugTest extends TestCase
         $model = new class extends TestModel {
             public function getSlugOptions(): SlugOptions
             {
-                return parent::getSlugOptions()->usingLanguage('ae');
+                return parent::getSlugOptions()->usingLanguage('de');
             }
         };
 
-        $model->name = 'أحمد محمد';
+        $model->name = 'Güte nacht';
         $model->save();
-        $this->assertEquals('أحمد-محمد', $model->url);
+        $this->assertEquals('guete-nacht', $model->url);
     }
 }


### PR DESCRIPTION
As discussed in https://github.com/spatie/laravel-sluggable/issues/34:

- Added $slugLanguage to `SlugOptions`
- Passed $slugLanguage to `generateNonUniqueSlug()` in `HasSlug`
- Added test to check if language gets set
- Updated README with an example on how to use `usingLanguage()`

First open source PR ever, be gentle! ;-)