### PR TITLE
Use Str::slug instead of str_slug helper for compatibility with Lumen

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ $model->save();
 echo $model->slug; // ouputs "activerecord-is-awesome"
 ```
 
-The slugs are generated with Laravels `str_slug` method, whereby spaces are converted to '-'.
+The slugs are generated with Laravels `Str::slug` method, whereby spaces are converted to '-'.
 
 Spatie is a webdesign agency based in Antwerp, Belgium. You'll find an overview of all our open source projects [on our website](https://spatie.be/opensource).
 
@@ -113,7 +113,7 @@ public function getSlugOptions() : SlugOptions
 }
 ```
 
-To set the language used by `str_slug` you may call `usingLanguage`
+To set the language used by `Str::slug` you may call `usingLanguage`
 
 ```php
 public function getSlugOptions() : SlugOptions

--- a/src/HasSlug.php
+++ b/src/HasSlug.php
@@ -2,6 +2,7 @@
 
 namespace Spatie\Sluggable;
 
+use Illuminate\Support\Str;
 use Illuminate\Database\Eloquent\Model;
 
 trait HasSlug
@@ -95,7 +96,7 @@ trait HasSlug
             return $this->$slugField;
         }
 
-        return str_slug($this->getSlugSourceString(), $this->slugOptions->slugSeparator, $this->slugOptions->slugLanguage);
+        return Str::slug($this->getSlugSourceString(), $this->slugOptions->slugSeparator, $this->slugOptions->slugLanguage);
     }
 
     /**

--- a/tests/Integration/HasSlugTest.php
+++ b/tests/Integration/HasSlugTest.php
@@ -2,6 +2,7 @@
 
 namespace Spatie\Sluggable\Test\Integration;
 
+use Illuminate\Support\Str;
 use Spatie\Sluggable\SlugOptions;
 
 class HasSlugTest extends TestCase
@@ -88,7 +89,7 @@ class HasSlugTest extends TestCase
             public function getSlugOptions(): SlugOptions
             {
                 return parent::getSlugOptions()->generateSlugsFrom(function (TestModel $model): string {
-                    return 'foo-'.str_slug($model->name);
+                    return 'foo-'.Str::slug($model->name);
                 });
             }
         };


### PR DESCRIPTION
Very useful package! I made a little change so it can be used with Lumen framework as well. 