### PR TITLE
Slug scopes

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,6 +168,7 @@ $model-save();
 $model->name = 'changed name';
 $model->save(); //slug stays "my-name"
 ```
+If you want to explicitly update the slug on the model you can call `generateSlug()` on your model at any time to make the slug according to your other options. Don't forget to `save()` the model to persist the update to your database.
 
 If you want unique slugs for a scope, such as "http://example.com/category1/my-slug" and "http://example.com/category2/my-slug", you can use `scopeTo()`
 

--- a/README.md
+++ b/README.md
@@ -169,7 +169,19 @@ $model->name = 'changed name';
 $model->save(); //slug stays "my-name"
 ```
 
-If you want to explicitly update the slug on the model you can call `generateSlug()` on your model at any time to make the slug according to your other options. Don't forget to `save()` the model to persist the update to your database.
+If you want unique slugs for a scope, such as "http://example.com/category1/my-slug" and "http://example.com/category2/my-slug", you can use `scopeTo()`
+
+```php
+public function getSlugOptions() : SlugOptions
+{
+    return SlugOptions::create()
+        ->scopeTo(function(Illuminate\Database\Eloquent\Builder $query) {
+            $query->where('category_id', $this->category_id);
+         });
+}
+```
+
+If category1 already has "my-slug", it will generate a unique slug.
 
 ## Changelog
 

--- a/src/HasSlug.php
+++ b/src/HasSlug.php
@@ -152,6 +152,7 @@ trait HasSlug
         return (bool) static::where($this->slugOptions->slugField, $slug)
             ->where($this->getKeyName(), '!=', $this->getKey() ?? '0')
             ->withoutGlobalScopes()
+            ->where($this->slugOptions->slugScopeTo)
             ->first();
     }
 
@@ -172,4 +173,5 @@ trait HasSlug
             throw InvalidOption::invalidMaximumLength();
         }
     }
+
 }

--- a/src/SlugOptions.php
+++ b/src/SlugOptions.php
@@ -28,9 +28,26 @@ class SlugOptions
     /** @var string */
     public $slugLanguage = 'en';
 
+    /** @var \Closure */
+    public $slugScopeTo;
+
     public static function create(): self
     {
         return new static();
+    }
+
+    public function __construct()
+    {
+        $this->setDefaultScope();
+    }
+
+    /**
+     * set default scope, so we have always a closure
+     */
+    protected function setDefaultScope() {
+        $this->slugScopeTo = function ($query) {
+
+        };
     }
 
     /**
@@ -94,6 +111,18 @@ class SlugOptions
     public function usingLanguage(string $language): self
     {
         $this->slugLanguage = $language;
+
+        return $this;
+    }
+
+    /**
+     *
+     * @param \Closure $closure
+     * @return SlugOptions
+     */
+    public function scopeTo(\Closure $closure): self
+    {
+        $this->slugScopeTo = $closure;
 
         return $this;
     }

--- a/tests/Integration/HasSlugTest.php
+++ b/tests/Integration/HasSlugTest.php
@@ -269,4 +269,34 @@ class HasSlugTest extends TestCase
         $model->save();
         $this->assertEquals('guete-nacht', $model->url);
     }
+
+    /** @test */
+    public function it_will_generate_same_slug_in_different_scopes()
+    {
+        $model = new class extends TestModel {
+            public function getSlugOptions(): SlugOptions
+            {
+                return parent::getSlugOptions()->scopeTo(function(\Illuminate\Database\Eloquent\Builder $query) {
+                    $query->where('other_field', $this->other_field);
+                });
+            }
+        };
+        $model->name = 'this is a test';
+        $model->other_field = 'scope_a';
+        $model->save();
+        $this->assertEquals('this-is-a-test', $model->url);
+
+        $secondModel = $model->newInstance();
+
+        $secondModel->name = 'this is a test';
+        $secondModel->other_field = 'scope_b';
+        $secondModel->save();
+        $this->assertEquals('this-is-a-test', $secondModel->url);
+
+        $thirdModel = $model->newInstance();
+        $thirdModel->name = 'this is a test';
+        $thirdModel->other_field = 'scope_a';
+        $thirdModel->save();
+        $this->assertEquals('this-is-a-test-1', $thirdModel->url);
+    }
 }


### PR DESCRIPTION
This PR adds the ability, to scope slugs to specific constraints.

If your site has different Categories/Systems whatever and you need unique scopes per Category, you can scope the slug to the category id.
So the slug "my-slug" can exists in both Category 1 and Category 2, but in Category 1 there can only be one "my-slug". 