### PR TITLE
Added closing back tick for code example.

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,7 +135,7 @@ $model->slug = 'my-custom-url';
 $model->save(); //slug is now "my-custom-url"; 
 ```
 
-If you don't want to create the slug when the model is initially created you can set use the `doNotGenerateSlugsOnCreate() function.
+If you don't want to create the slug when the model is initially created you can set use the `doNotGenerateSlugsOnCreate()` function.
 
 ```php
 public function getSlugOptions() : SlugOptions


### PR DESCRIPTION
Simply missing a closing back tick on the "doNotGenerateSlugsOnCreate" examples.