### PR TITLE
fix #84 

### DIFF
--- a/src/HasSlug.php
+++ b/src/HasSlug.php
@@ -90,9 +90,9 @@ trait HasSlug
      */
     protected function generateNonUniqueSlug(): string
     {
-        if ($this->hasCustomSlugBeenUsed()) {
-            $slugField = $this->slugOptions->slugField;
+        $slugField = $this->slugOptions->slugField;
 
+        if ($this->hasCustomSlugBeenUsed() && !empty($this->$slugField)) {
             return $this->$slugField;
         }
 

--- a/tests/Integration/HasSlugTest.php
+++ b/tests/Integration/HasSlugTest.php
@@ -35,6 +35,17 @@ class HasSlugTest extends TestCase
     }
 
     /** @test */
+    public function it_will_use_the_source_field_if_the_slug_field_is_empty()
+    {
+        $model = TestModel::create(['name' => 'this is a test']);
+
+        $model->url = null;
+        $model->save();
+
+        $this->assertEquals('this-is-a-test', $model->url);
+    }
+
+    /** @test */
     public function it_will_update_the_slug_when_the_source_field_is_changed()
     {
         $model = TestModel::create(['name' => 'this is a test']);


### PR DESCRIPTION
Hello,

i'm not sure if this is the way you wanted it to be fixed but now if the field named slug is empty it will use the source field to create the slug.