### PR TITLE
Add matrix to travis to tests against all supported version.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,4 +24,4 @@ before_script:
   - travis_retry composer update ${COMPOSER_FLAGS} --no-interaction --prefer-source
 
 script:
-  - phpunit --coverage-text --coverage-clover=coverage.clover
+  - ./vendor/bin/phpunit --coverage-text --coverage-clover=coverage.clover

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,12 +6,21 @@ php:
   - 7.3
 
 env:
-  matrix:
-    - COMPOSER_FLAGS="--prefer-lowest"
+  global:
     - COMPOSER_FLAGS=""
+  matrix:
+    - LARAVEL=5.6.*
+    - LARAVEL=5.7.*
+    - LARAVEL=5.8.*
+    - COMPOSER_FLAGS="--prefer-lowest" LARAVEL=5.6.*
+    - COMPOSER_FLAGS="--prefer-lowest" LARAVEL=5.7.*
+    - COMPOSER_FLAGS="--prefer-lowest" LARAVEL=5.8.*
+    
+before_install:
+  - travis_retry composer self-update
 
 before_script:
-  - travis_retry composer self-update
+  - travis_retry composer require "laravel/framework=${LARAVEL}" --prefer-source --no-interaction --no-suggest
   - travis_retry composer update ${COMPOSER_FLAGS} --no-interaction --prefer-source
 
 script:

--- a/composer.json
+++ b/composer.json
@@ -21,8 +21,7 @@
         "illuminate/support": "~5.6.0|~5.7.0|~5.8.0"
     },
     "require-dev": {
-        "orchestra/testbench": "~3.6.0|~3.7.0|~3.8.0",
-        "phpunit/phpunit": "^7.5|^8.0"
+        "orchestra/testbench": "~3.6.0|~3.7.0|~3.8.0"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
         "illuminate/support": "~5.6.0|~5.7.0|~5.8.0"
     },
     "require-dev": {
-        "orchestra/testbench": "~3.8.0",
+        "orchestra/testbench": "~3.6.0|~3.7.0|~3.8.0",
         "phpunit/phpunit": "^7.5|^8.0"
     },
     "autoload": {


### PR DESCRIPTION
### Changes

- Use `phpunit` installed through composer instead of prebuilt by Travis.
- Test against each version of Laravel 5.6, 5.7 and 5.8 using "latest-stable" or "lowest-stable" configuration.
- Remove `phpunit/phpunit` deps since it's already managed by `orchestra/testbench` to installed the most recommended version based on each Laravel version.