### PR TITLE
Update README.md's USAGE section

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,8 @@ Your Eloquent models should use the `Spatie\Sluggable\HasSlug` trait and the `Sp
 
 The trait contains an abstract method `getSlugOptions()` that you must implement yourself. 
 
+Your models' migrations should have a field to save the generated slug to.
+
 Here's an example of how to implement the trait:
 
 ```php
@@ -57,6 +59,82 @@ class YourEloquentModel extends Model
         return SlugOptions::create()
             ->generateSlugsFrom('name')
             ->saveSlugsTo('slug');
+    }
+}
+```
+
+With its migration:
+
+```php
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class CreateYourEloquentModelTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::create('your_eloquent_models', function (Blueprint $table) {
+            $table->increments('id');
+            $table->string('slug'); // Field name same as your `saveSlugsTo`
+            $table->string('name');
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::dropIfExists('your_eloquent_models');
+    }
+}
+
+```
+
+To use the generated slug in routes, remember to use Laravel's [implicit route model binding](https://laravel.com/docs/5.8/routing#implicit-binding):
+
+```php
+<?php
+
+namespace App;
+
+use Spatie\Sluggable\HasSlug;
+use Spatie\Sluggable\SlugOptions;
+use Illuminate\Database\Eloquent\Model;
+
+class YourEloquentModel extends Model
+{
+    use HasSlug;
+    
+    /**
+     * Get the options for generating the slug.
+     */
+    public function getSlugOptions() : SlugOptions
+    {
+        return SlugOptions::create()
+            ->generateSlugsFrom('name')
+            ->saveSlugsTo('slug');
+    }
+    
+    /**
+     * Get the route key for the model.
+     *
+     * @return string
+     */
+    public function getRouteKeyName()
+    {
+        return 'slug';
     }
 }
 ```

--- a/README.md
+++ b/README.md
@@ -66,8 +66,6 @@ class YourEloquentModel extends Model
 With its migration:
 
 ```php
-<?php
-
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
@@ -88,16 +86,6 @@ class CreateYourEloquentModelTable extends Migration
             $table->timestamps();
         });
     }
-
-    /**
-     * Reverse the migrations.
-     *
-     * @return void
-     */
-    public function down()
-    {
-        Schema::dropIfExists('your_eloquent_models');
-    }
 }
 
 ```
@@ -105,8 +93,6 @@ class CreateYourEloquentModelTable extends Migration
 To use the generated slug in routes, remember to use Laravel's [implicit route model binding](https://laravel.com/docs/5.8/routing#implicit-binding):
 
 ```php
-<?php
-
 namespace App;
 
 use Spatie\Sluggable\HasSlug;


### PR DESCRIPTION
For better understanding, I added parts to inform users about:

1) Adding the slug field to their migration.
2) Using Laravel's Implicit Route Model Binding to use the generated slug field.

I was a bit confused how the package worked as I thought that maybe the `HasSlug` trait associated a `morphToMany` relationship to a `Slug` model from this package, to generate and retrieve slugs.

This should make it explicit that the package generates the slug and and saves it to a specified field in the model's migration.