### PR TITLE
Add support for Laravel 6.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,12 +16,12 @@
         }
     ],
     "require": {
-        "php" : ">=7.1.3",
-        "illuminate/database": "~5.6.0|~5.7.0|~5.8.0",
-        "illuminate/support": "~5.6.0|~5.7.0|~5.8.0"
+        "php" : "^7.2",
+        "illuminate/database": "~5.6.0|~5.7.0|~5.8.0|~6.0.0",
+        "illuminate/support": "~5.6.0|~5.7.0|~5.8.0|~6.0.0"
     },
     "require-dev": {
-        "orchestra/testbench": "~3.6.0|~3.7.0|~3.8.0"
+        "orchestra/testbench": "~3.6.0|~3.7.0|~3.8.0|~3.9.0|~4.0.0"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
Referenced in https://github.com/spatie/laravel-sluggable/issues/113

I am unsure if the version constraint for PHP 7.2 is required. Laravel 6.0 requires 7.2+ but, I think maybe leaving the PHP version at `>=7.1.3` is fine and allowing the project itself to define the PHP version. If you have feedback that'd be great!

Thanks!