### PR TITLE
Allow route binding of slug in addition to routeKeyName

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ class CreateYourEloquentModelTable extends Migration
 
 ```
 
-To use the generated slug in routes, remember to use Laravel's [implicit route model binding](https://laravel.com/docs/5.8/routing#implicit-binding):
+To use the generated slug as your only route key, use Laravel's [implicit route model binding](https://laravel.com/docs/5.8/routing#implicit-binding):
 
 ```php
 namespace App;
@@ -121,6 +121,32 @@ class YourEloquentModel extends Model
     public function getRouteKeyName()
     {
         return 'slug';
+    }
+}
+```
+
+To allow the use of either the generated slug OR the route key defined in your model (by default this is the model's ID column) you may add `->allowRouteBinding()` to your SlugOptions configuration chain. For example you want to be able to use the model's ID (or any other column that you specify in the `getRouteKeyName()`) on the administration panel and the slug in the front-end, this will allow you to interchange the slug and chosen route key name.
+
+```php
+namespace App;
+
+use Spatie\Sluggable\HasSlug;
+use Spatie\Sluggable\SlugOptions;
+use Illuminate\Database\Eloquent\Model;
+
+class YourEloquentModel extends Model
+{
+    use HasSlug;
+    
+    /**
+     * Get the options for generating the slug.
+     */
+    public function getSlugOptions() : SlugOptions
+    {
+        return SlugOptions::create()
+            ->generateSlugsFrom('name')
+            ->saveSlugsTo('slug')
+            ->allowRouteBinding();
     }
 }
 ```

--- a/src/HasSlug.php
+++ b/src/HasSlug.php
@@ -52,6 +52,17 @@ trait HasSlug
         $this->addSlug();
     }
 
+    public function resolveRouteBinding($value)
+    {
+        if ($this->getSlugOptions()->routeBinding) {
+            return $this->where($this->getRouteKeyName(), $value)
+                        ->orWhere($this->getSlugOptions()->slugField, $value)
+                        ->first();
+        } else {
+            return parent::resolveRouteBinding($value);
+        }
+    }
+
     protected function addSlug()
     {
         $this->ensureValidSlugOptions();

--- a/src/HasSlug.php
+++ b/src/HasSlug.php
@@ -58,9 +58,9 @@ trait HasSlug
             return $this->where($this->getRouteKeyName(), $value)
                         ->orWhere($this->getSlugOptions()->slugField, $value)
                         ->first();
-        } else {
-            return parent::resolveRouteBinding($value);
         }
+
+        return parent::resolveRouteBinding($value);
     }
 
     protected function addSlug()

--- a/src/SlugOptions.php
+++ b/src/SlugOptions.php
@@ -28,6 +28,9 @@ class SlugOptions
     /** @var string */
     public $slugLanguage = 'en';
 
+    /** @var bool */
+    public $routeBinding = false;
+
     public static function create(): self
     {
         return new static();
@@ -94,6 +97,13 @@ class SlugOptions
     public function usingLanguage(string $language): self
     {
         $this->slugLanguage = $language;
+
+        return $this;
+    }
+
+    public function allowRouteBinding(): self
+    {
+        $this->routeBinding = false;
 
         return $this;
     }

--- a/tests/Integration/HasSlugTest.php
+++ b/tests/Integration/HasSlugTest.php
@@ -291,4 +291,31 @@ class HasSlugTest extends TestCase
             $this->assertEquals("this-is-a-test-{$i}", $model->url);
         }
     }
+
+    /** @test */
+    public function it_will_not_include_slug_on_route_binding_by_default()
+    {
+        $model = TestModel::create(['name' => 'this is a test']);
+
+        $reponse = $this->get('tests/'.$model->url);
+
+        $reponse->assertNotFound();
+    }
+
+    /** @test */
+    public function it_will_include_slug_on_route_binding_when_configured_to()
+    {
+        $class = new class extends TestModel {
+            public function getSlugOptions(): SlugOptions
+            {
+                return parent::getSlugOptions()->allowRouteBinding();
+            }
+        };
+
+        $model = $class::create(['name' => 'this is a test']);
+
+        $reponse = $this->get('tests/'.$model->url);
+
+        $reponse->assertOk()->assertJson($model->toArray());
+    }
 }

--- a/tests/Integration/TestCase.php
+++ b/tests/Integration/TestCase.php
@@ -33,7 +33,7 @@ abstract class TestCase extends Orchestra
             'prefix' => '',
         ]);
 
-        $app['router']->get('tests/{testModel}', function(TestModel $testModel) {
+        $app['router']->get('tests/{testModel}', function (TestModel $testModel) {
             return $testModel;
         });
     }

--- a/tests/Integration/TestCase.php
+++ b/tests/Integration/TestCase.php
@@ -32,6 +32,10 @@ abstract class TestCase extends Orchestra
             'database' => $this->getTempDirectory().'/database.sqlite',
             'prefix' => '',
         ]);
+
+        $app['router']->get('tests/{testModel}', function(TestModel $testModel) {
+            return $testModel;
+        });
     }
 
     /**


### PR DESCRIPTION
This pull request adds a method to allow the generated slug to be used along side the default (or overridden) `getRouteKeyName()` method. Simply adding another method on the SlugOptions configuration chain can opt-in to this feature. With the addition of the `allowRouteBinding()` in the config you may now instantly use the slug without worrying about converting the whole system to slugs (and it just feels better to me :P)

I'm struggling to find how I can reliably test this so, please if you have any guidance I would love to hear it!

I know that I usually add this feature as another trait that extends the `HasSlug` from this package but, I would like to put this out to maybe anyone who wants to do this with just the package.

Please let me know how you feel about this and if you have any constructive feedback please, I'm all ears!