### PR TITLE
Support minimum php version same as Laravel 7

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
         }
     ],
     "require": {
-        "php" : "^7.4",
+        "php" : "^7.2.5",
         "illuminate/database": "^7.0",
         "illuminate/support": "^7.0"
     },


### PR DESCRIPTION
Unless the library specifically uses features from php4 it is best to stay in line with the minimum requirements of Laravel. 
https://laravel.com/docs/7.x/upgrade#upgrade-7.0