### PR TITLE
Use method for retrieving incrementing status of the model

### DIFF
--- a/src/HasSlug.php
+++ b/src/HasSlug.php
@@ -115,7 +115,7 @@ trait HasSlug
     {
         $key = $this->getKey();
 
-        if ($this->incrementing) {
+        if ($this->getIncrementing()) {
             $key ??= '0';
         }
 


### PR DESCRIPTION
This PR updates the check if the model is using an incremental key by calling the `getIncrementing()` method rather than reading the property. This is more flexible as there are some cases where you can't override the property, for example in a trait.