### PR TITLE
FIX: fix bug that causes empty slugs when dealing with multi-bytes chars

### DIFF
--- a/src/HasSlug.php
+++ b/src/HasSlug.php
@@ -89,14 +89,14 @@ trait HasSlug
         if (is_callable($this->slugOptions->generateSlugFrom)) {
             $slugSourceString = call_user_func($this->slugOptions->generateSlugFrom, $this);
 
-            return substr($slugSourceString, 0, $this->slugOptions->maximumLength);
+            return $this->generateSubstring($slugSourceString);
         }
 
         $slugSourceString = collect($this->slugOptions->generateSlugFrom)
             ->map(fn (string $fieldName): string => data_get($this, $fieldName, ''))
             ->implode($this->slugOptions->slugSeparator);
 
-        return substr($slugSourceString, 0, $this->slugOptions->maximumLength);
+        return $this->generateSubstring($slugSourceString);
     }
 
     protected function makeSlugUnique(string $slug): string
@@ -148,5 +148,20 @@ trait HasSlug
         if ($this->slugOptions->maximumLength <= 0) {
             throw InvalidOption::invalidMaximumLength();
         }
+    }
+
+    /**
+     * Helper function to handle multi-bytes strings if
+     * the module mb_substr is present
+     * Default to substr otherwise
+     */
+    protected function generateSubstring($slugSourceString)
+    {
+
+        if (function_exists('mb_substr')) {
+            return mb_substr($slugSourceString, 0, $this->slugOptions->maximumLength);
+        }
+
+        return substr($slugSourceString, 0, $this->slugOptions->maximumLength);
     }
 }

--- a/src/HasSlug.php
+++ b/src/HasSlug.php
@@ -151,9 +151,8 @@ trait HasSlug
     }
 
     /**
-     * Helper function to handle multi-bytes strings if
-     * the module mb_substr is present
-     * Default to substr otherwise
+     * Helper function to handle multi-bytes strings if the module mb_substr is present,
+     * default to substr otherwise.
      */
     protected function generateSubstring($slugSourceString)
     {

--- a/src/HasSlug.php
+++ b/src/HasSlug.php
@@ -156,7 +156,6 @@ trait HasSlug
      */
     protected function generateSubstring($slugSourceString)
     {
-
         if (function_exists('mb_substr')) {
             return mb_substr($slugSourceString, 0, $this->slugOptions->maximumLength);
         }

--- a/tests/HasSlugTest.php
+++ b/tests/HasSlugTest.php
@@ -168,6 +168,18 @@ class HasSlugTest extends TestCase
         ];
     }
 
+    /**
+     * @test
+     */
+    public function it_can_handle_multibytes_characters_cutting_when_generating_the_slug()
+    {
+        $model = TestModel::create(['name' => 'là']);
+        $model->setSlugOptions($model->getSlugOptions()->slugsShouldBeNoLongerThan(2));
+        $model->generateSlug();
+
+        $this->assertEquals('la', $model->url);
+    }
+
     /** @test */
     public function it_can_handle_overwrites_when_updating_a_model()
     {


### PR DESCRIPTION
The use of substr caused a possible bug if the limit size of the slug where to end on a special character. This character would be cut because substr limit count is byte based. 
Therefore, invalid chars (garbage values) were introduced into the string. Str::slug would then returns an empty value as result. 
This resulted in many slugs being "", "-1", "-2", and so on.
This commit aims at trying first to use mb_substr if available(*), which will handle more properly the string

* mb_substr seems to be a module, so i didn't know if it was safe to just throw it in there instead of substr. I took the safe solution of keeping them both, having substr as safety net.

I added a small test that reproduces the bug. 

This is my first meaningful pull request, any constructive comment is welcome. I hope it will help. 
Greetings from Namen, BE !

PS: there was a test failing, previous to any change:
-'a-euro'
+'aeur'
Not sure if it is really a mistake. 