### PR TITLE
Improves error handling.

### DIFF
--- a/src/HasSlug.php
+++ b/src/HasSlug.php
@@ -142,7 +142,21 @@ trait HasSlug
 
     protected function ensureValidSlugOptions()
     {
-        if (is_array($this->slugOptions->generateSlugFrom) && ! count($this->slugOptions->generateSlugFrom)) {
+        if (is_array($this->slugOptions->generateSlugFrom)) {
+             if ( ! count($this->slugOptions->generateSlugFrom)) {
+                throw InvalidOption::missingFromField();
+            }
+
+            foreach ($this->slugOptions->generateSlugFrom as $source) {
+                if ( ! $this->validateSource($source)) {
+                    $invalidSources[] = $source;
+                }
+            }
+
+            throw InvalidOption::missingFromField($invalidSources);
+        }
+
+        if ( ! $this->validateSource($this->slugSource)) {
             throw InvalidOption::missingFromField();
         }
 
@@ -153,6 +167,15 @@ trait HasSlug
         if ($this->slugOptions->maximumLength <= 0) {
             throw InvalidOption::invalidMaximumLength();
         }
+    }
+
+    public function validateSource($source)
+    {
+        if ( ! $source || !data_get($this, $source, '')) {
+            return false;
+        }
+
+        return true;
     }
 
     /**

--- a/src/InvalidOption.php
+++ b/src/InvalidOption.php
@@ -6,8 +6,14 @@ use Exception;
 
 class InvalidOption extends Exception
 {
-    public static function missingFromField()
+    public static function missingFromField(Array $invalidFields = [])
     {
+        if ( ! empty($invalidFields)) {
+            $invalidFields = collect($invalidFields)->implode(', ');
+
+            return new static("Fields {$invalidFields} are not valid sources for sluggification");
+        }
+
         return new static('Could not determine which fields should be sluggified');
     }
 


### PR DESCRIPTION
Hey there.

When the source field provided is either null or the name of a non existent column, we end up with decrementing negative integers as slugs (seemingly). Actually it is just the case that the non unique created slug is just an empty string and the incremented integer is appended normally as it should in HasSlug.php:113 
$slug = $originalSlug.$this->slugOptions->slugSeparator.$i++;

I believe, this is confusing, and i went ahead to check if data exists in the column provided as source field (as is done when the slug is created).  In the cases that conclude to empty string slug, i think that an exception should be thrown (or no slug created... that is up for discussion). 

Finally i think that in the case of multiple source fields, a more verbose error should be thrown, as suggested in the changes made in InvalidOption.php

If there is anything wrong with my pull request feel free to contact me.
Thanks for the awesome package.

Best Regards,
Marios.