### PR TITLE
Add support for Laravel 8

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -10,9 +10,11 @@ jobs:
       fail-fast: false
       matrix:
         php: [7.4]
-        laravel: [7.*]
+        laravel: [7.*, 8.*]
         dependency-version: [prefer-lowest, prefer-stable]
         include:
+          - laravel: 8.*
+            testbench: 6.*
           - laravel: 7.*
             testbench: 5.*
 

--- a/composer.json
+++ b/composer.json
@@ -17,11 +17,11 @@
     ],
     "require": {
         "php" : "^7.4",
-        "illuminate/database": "^7.0",
-        "illuminate/support": "^7.0.5"
+        "illuminate/database": "^7.0|^8.0",
+        "illuminate/support": "^7.0.5|^8.0"
     },
     "require-dev": {
-        "orchestra/testbench": "^5.0",
+        "orchestra/testbench": "^5.0|^6.0",
         "spatie/laravel-translatable": "^4.3",
         "friendsofphp/php-cs-fixer": "^2.16"
     },

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,22 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit bootstrap="vendor/autoload.php"
-         backupGlobals="false"
-         backupStaticAttributes="false"
-         colors="true"
-         verbose="true"
-         convertErrorsToExceptions="true"
-         convertNoticesToExceptions="true"
-         convertWarningsToExceptions="true"
-         processIsolation="false"
-         stopOnFailure="false">
-    <testsuites>
-        <testsuite name="League Test Suite">
-            <directory>tests</directory>
-        </testsuite>
-    </testsuites>
-    <filter>
-        <whitelist>
-            <directory suffix=".php">src/</directory>
-        </whitelist>
-    </filter>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" bootstrap="vendor/autoload.php" backupGlobals="false" backupStaticAttributes="false" colors="true" verbose="true" convertErrorsToExceptions="true" convertNoticesToExceptions="true" convertWarningsToExceptions="true" processIsolation="false" stopOnFailure="false" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
+  <coverage>
+    <include>
+      <directory suffix=".php">src/</directory>
+    </include>
+  </coverage>
+  <testsuites>
+    <testsuite name="League Test Suite">
+      <directory>tests</directory>
+    </testsuite>
+  </testsuites>
 </phpunit>


### PR DESCRIPTION
Adds support for the soon-to-be-released Laravel 8.

~~This pull request depends on https://github.com/spatie/laravel-translatable/pull/226~~ PR already merged into master.

~~If a new release is tagged for `spatie/laravel-translatable`, then it needs to be also updated here.~~ Update to package was tagged with a minor version, so no other changes are needed here.

~~Apart from the "unmet requirements" for tests with Laravel 8 support, the tests are failing because of issue #163.~~ Fix already merged into master, so tests should be green now.