### PR TITLE
Fixes failing test that uses weird characters when generating the slug

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
     "require": {
         "php" : "^7.4",
         "illuminate/database": "^7.0",
-        "illuminate/support": "^7.0"
+        "illuminate/support": "^7.0.5"
     },
     "require-dev": {
         "orchestra/testbench": "^5.0",

--- a/tests/HasSlugTest.php
+++ b/tests/HasSlugTest.php
@@ -162,7 +162,7 @@ class HasSlugTest extends TestCase
             ['é', 'e'],
             ['è', 'e'],
             ['à', 'a'],
-            ['a€', 'a-euro'],
+            ['a€', 'aeur'],
             ['ß', 'ss'],
             ['a/ ', 'a'],
         ];


### PR DESCRIPTION
This pull request fixes the failing test [it_can_handle_weird_characters_when_generating_the_slug](https://github.com/spatie/laravel-sluggable/blob/5b0c995ad7c108e160d3b11382dc53eebb7d6159/tests/HasSlugTest.php#L152). This error was introduced because the framework changed the behavior of the `Str::slug` method with release [v7.0.5](https://github.com/laravel/framework/releases/tag/v7.0.5)

Fixes #163