### PR TITLE
Fixed an incompatibility bug with postgresql uuid column

### DIFF
--- a/src/HasSlug.php
+++ b/src/HasSlug.php
@@ -118,15 +118,12 @@ trait HasSlug
 
     protected function otherRecordExistsWithSlug(string $slug): bool
     {
-        $key = $this->getKey();
-
-        if ($this->getIncrementing()) {
-            $key ??= '0';
-        }
-
         $query = static::where($this->slugOptions->slugField, $slug)
-            ->where($this->getKeyName(), '!=', $key)
             ->withoutGlobalScopes();
+
+        if ($this->exists()) {
+            $query->where($this->getKeyName(), '!=', $this->getKey());
+        }
 
         if ($this->usesSoftDeletes()) {
             $query->withTrashed();


### PR DESCRIPTION
The current existence check always attempts to do a lookup on the key of a model, even though is is only required when creating a slug for an already existing model. By falling back to a `where id != 0` default, a QueryException is thrown when the key is of the UUID type in PostgreSQL.

This PR fixes that issue, by only doing a look-up on the primary key when the model already exists.