### PR TITLE
Fix Eloquent model checking

### DIFF
--- a/src/HasSlug.php
+++ b/src/HasSlug.php
@@ -133,7 +133,7 @@ trait HasSlug
         $query = static::where($this->slugOptions->slugField, $slug)
             ->withoutGlobalScopes();
 
-        if ($this->exists()) {
+        if ($this->exists) {
             $query->where($this->getKeyName(), '!=', $this->getKey());
         }
 


### PR DESCRIPTION
Hi,

Following a bug on my app, I propose a modification of the check of model existence in `otherRecordExistsWithSlug`.

The `$this->exists()` method performs a global check of table (excluding soft delete), and doesn't check the real existence of the model. In addition it can lead to unexpected behavior such as
recreating a new slug if the whole table is soft-deleted because `$this->exists()` will return `false`.

Example request with this method (thanks Ray 💯) :

    select exists(select * from `accounts` where `accounts`.`deleted_at` is null) as `exists`

All entries have a `deleted_at` column filled in, so when I restore an entry the slug changes from 'example-slug' to 'example-slug-1' because the eloquent model is not excluded from the request.

I propose to replace `$this->exists()` by `$this->exists` which directly confirms the existence of the model.

I don't know the impact of this change on the previous PR regarding postgresql.

I'm sorry in advance for my approximate English where if I do something wrong it's only my second PR on an open-source project.

Regards...