### PR TITLE
Added translatable slug overriding

### DIFF
--- a/src/HasTranslatableSlug.php
+++ b/src/HasTranslatableSlug.php
@@ -58,14 +58,13 @@ trait HasTranslatableSlug
         $slugField = $this->slugOptions->slugField;
         $slugString = $this->getSlugSourceString();
 
-        $originalSlug = $this->getOriginal($slugField)[$this->getLocale()] ?? null;
-        $newSlug = $this->getTranslations($slugField)[$this->getLocale()] ?? null;
+        $slug = $this->getTranslations($slugField)[$this->getLocale()] ?? null;
 
-        $hasCustomSlug = $this->hasCustomSlugBeenUsed() && !empty($newSlug);
-        $hasChangedCustomSlug = $slugString == $this->getOriginalSourceString() && !is_null($newSlug) && $originalSlug == $newSlug;
+        $hasCustomSlug = $this->hasCustomSlugBeenUsed() && !empty($slug);
+        $hasNonChangedCustomSlug = !$this->slugIsBasedOnTitle() && !empty($slug);
 
-        if($hasCustomSlug || $hasChangedCustomSlug){
-            $slugString = $newSlug;
+        if($hasCustomSlug || $hasNonChangedCustomSlug){
+            $slugString = $slug;
         }
 
         return Str::slug($slugString, $this->slugOptions->slugSeparator, $this->slugOptions->slugLanguage);
@@ -89,6 +88,15 @@ trait HasTranslatableSlug
     protected function getSlugSourceStringFromCallable(): string
     {
         return call_user_func($this->slugOptions->generateSlugFrom, $this, $this->getLocale());
+    }
+
+    protected function slugIsBasedOnTitle()
+    {
+        $slugField = $this->slugOptions->slugField;
+        $titleSlug = Str::slug($this->getOriginalSourceString(), $this->slugOptions->slugSeparator, $this->slugOptions->slugLanguage);
+        $currentSlug = $this->getTranslations($slugField)[$this->getLocale()] ?? null;
+
+        return $titleSlug == $currentSlug;
     }
 
     protected function hasCustomSlugBeenUsed(): bool

--- a/src/HasTranslatableSlug.php
+++ b/src/HasTranslatableSlug.php
@@ -70,6 +70,20 @@ trait HasTranslatableSlug
         return Str::slug($slugString, $this->slugOptions->slugSeparator, $this->slugOptions->slugLanguage);
     }
 
+    protected function getSlugSourceStringFromCallable(): string
+    {
+        return call_user_func($this->slugOptions->generateSlugFrom, $this, $this->getLocale());
+    }
+
+    protected function slugIsBasedOnTitle()
+    {
+        $slugField = $this->slugOptions->slugField;
+        $titleSlug = Str::slug($this->getOriginalSourceString(), $this->slugOptions->slugSeparator, $this->slugOptions->slugLanguage);
+        $currentSlug = $this->getTranslations($slugField)[$this->getLocale()] ?? null;
+
+        return $titleSlug === $currentSlug;
+    }
+
     protected function getOriginalSourceString()
     {
         if (is_callable($this->slugOptions->generateSlugFrom)) {
@@ -85,26 +99,12 @@ trait HasTranslatableSlug
         return $this->generateSubstring($slugSourceString);
     }
 
-    protected function getSlugSourceStringFromCallable(): string
-    {
-        return call_user_func($this->slugOptions->generateSlugFrom, $this, $this->getLocale());
-    }
-
-    protected function slugIsBasedOnTitle()
-    {
-        $slugField = $this->slugOptions->slugField;
-        $titleSlug = Str::slug($this->getOriginalSourceString(), $this->slugOptions->slugSeparator, $this->slugOptions->slugLanguage);
-        $currentSlug = $this->getTranslations($slugField)[$this->getLocale()] ?? null;
-
-        return $titleSlug == $currentSlug;
-    }
-
     protected function hasCustomSlugBeenUsed(): bool
     {
         $slugField = $this->slugOptions->slugField;
         $originalSlug = $this->getOriginal($slugField)[$this->getLocale()] ?? null;
         $newSlug = $this->getTranslations($slugField)[$this->getLocale()] ?? null;
 
-        return $originalSlug != $newSlug;
+        return $originalSlug !== $newSlug;
     }
 }

--- a/src/HasTranslatableSlug.php
+++ b/src/HasTranslatableSlug.php
@@ -59,6 +59,10 @@ trait HasTranslatableSlug
 
     protected function hasCustomSlugBeenUsed(): bool
     {
-        return false;
+        $slugField = $this->slugOptions->slugField;
+        $originalSlug = $this->getOriginal($slugField)[$this->getLocale()] ?? null;
+        $newSlug = $this->getTranslations($slugField)[$this->getLocale()] ?? null;
+
+        return $originalSlug != $newSlug;
     }
 }

--- a/tests/HasTranslatableSlugTest.php
+++ b/tests/HasTranslatableSlugTest.php
@@ -153,4 +153,67 @@ class HasTranslatableSlugTest extends TestCase
         $this->assertSame('name-en-other-en', $this->testModel->slug);
         $this->assertSame('name-nl-other-nl', $this->testModel->getTranslation('slug', 'nl'));
     }
+
+    /** @test */
+    public function it_can_handle_overwrites_when_creating_a_model()
+    {
+        $this->testModel->setTranslation('name', 'en', 'Test value EN');
+        $this->testModel->setTranslation('name', 'nl', 'Test value NL');
+        $this->testModel->setTranslation('slug', 'nl', 'updated-value-nl');
+        $this->testModel->setTranslation('slug', 'en', 'updated-value-en');
+
+        $this->testModel->save();
+
+        $this->assertSame('updated-value-en', $this->testModel->slug);
+        $this->assertSame('updated-value-nl', $this->testModel->getTranslation('slug', 'nl'));
+    }
+
+    /** @test */
+    public function it_can_handle_overwrites_when_updating_a_model()
+    {
+        $this->testModel->setTranslation('name', 'en', 'Test value EN');
+        $this->testModel->setTranslation('name', 'nl', 'Test value NL');
+        $this->testModel->save();
+
+        $this->testModel->setTranslation('slug', 'nl', 'updated-value-nl');
+        $this->testModel->setTranslation('slug', 'en', 'updated-value-en');
+        $this->testModel->save();
+
+        $this->assertSame('updated-value-en', $this->testModel->slug);
+        $this->assertSame('updated-value-nl', $this->testModel->getTranslation('slug', 'nl'));
+    }
+
+    /** @test */
+    public function it_can_handle_overwrites_for_one_item_when_updating_a_model()
+    {
+        $this->testModel->setTranslation('name', 'en', 'Test value EN');
+        $this->testModel->setTranslation('name', 'nl', 'Test value NL');
+        $this->testModel->save();
+
+        $this->testModel->setTranslation('slug', 'nl', 'updated-value-nl');
+        $this->testModel->save();
+
+        $this->assertSame('test-value-en', $this->testModel->slug);
+        $this->assertSame('updated-value-nl', $this->testModel->getTranslation('slug', 'nl'));
+    }
+
+    /** @test */
+    public function it_can_handle_duplicates_when_overwriting_a_slug()
+    {
+        $this->testModel->setTranslation('name', 'en', 'Test value EN');
+        $this->testModel->setTranslation('name', 'nl', 'Test value NL');
+        $this->testModel->save();
+
+        $newModel = new $this->testModel;
+        $newModel->setTranslation('name', 'en', 'Test value 2 EN');
+        $newModel->setTranslation('name', 'nl', 'Test value 2 NL');
+        $newModel->save();
+
+        $newModel->setTranslation('slug', 'en', 'test-value-en');
+        $newModel->setTranslation('slug', 'nl', 'test-value-nl');
+        $newModel->save();
+
+        $this->assertSame('test-value-en-1', $newModel->slug);
+        $this->assertSame('test-value-nl-1', $newModel->getTranslation('slug', 'nl'));
+    }
 }

--- a/tests/HasTranslatableSlugTest.php
+++ b/tests/HasTranslatableSlugTest.php
@@ -159,8 +159,8 @@ class HasTranslatableSlugTest extends TestCase
     {
         $this->testModel->setTranslation('name', 'en', 'Test value EN');
         $this->testModel->setTranslation('name', 'nl', 'Test value NL');
-        $this->testModel->setTranslation('slug', 'nl', 'updated-value-nl');
         $this->testModel->setTranslation('slug', 'en', 'updated-value-en');
+        $this->testModel->setTranslation('slug', 'nl', 'updated-value-nl');
 
         $this->testModel->save();
 
@@ -175,8 +175,8 @@ class HasTranslatableSlugTest extends TestCase
         $this->testModel->setTranslation('name', 'nl', 'Test value NL');
         $this->testModel->save();
 
-        $this->testModel->setTranslation('slug', 'nl', 'updated-value-nl');
         $this->testModel->setTranslation('slug', 'en', 'updated-value-en');
+        $this->testModel->setTranslation('slug', 'nl', 'updated-value-nl');
         $this->testModel->save();
 
         $this->assertSame('updated-value-en', $this->testModel->slug);

--- a/tests/HasTranslatableSlugTest.php
+++ b/tests/HasTranslatableSlugTest.php
@@ -198,6 +198,22 @@ class HasTranslatableSlugTest extends TestCase
     }
 
     /** @test */
+    public function it_can_handle_overwrites_for_one_item_when_updating_a_model_with_custom_slugs()
+    {
+        $this->testModel->setTranslation('name', 'en', 'Test value EN');
+        $this->testModel->setTranslation('name', 'nl', 'Test value NL');
+        $this->testModel->setTranslation('slug', 'en', 'Test slug EN');
+        $this->testModel->setTranslation('slug', 'nl', 'Test slug NL');
+        $this->testModel->save();
+
+        $this->testModel->setTranslation('slug', 'nl', 'updated-value-nl');
+        $this->testModel->save();
+
+        $this->assertSame('test-slug-en', $this->testModel->slug);
+        $this->assertSame('updated-value-nl', $this->testModel->getTranslation('slug', 'nl'));
+    }
+
+    /** @test */
     public function it_can_handle_duplicates_when_overwriting_a_slug()
     {
         $this->testModel->setTranslation('name', 'en', 'Test value EN');


### PR DESCRIPTION
I noticed slug overriding with the spatie translatable package was not possible yet. This PR fixes this. 
