### PR TITLE
Bugfix for updating slugs generated from a callback

### DIFF
--- a/src/HasTranslatableSlug.php
+++ b/src/HasTranslatableSlug.php
@@ -60,8 +60,9 @@ trait HasTranslatableSlug
 
         $slug = $this->getTranslations($slugField)[$this->getLocale()] ?? null;
 
+        $slugGeneratedFromCallable = is_callable($this->slugOptions->generateSlugFrom);
         $hasCustomSlug = $this->hasCustomSlugBeenUsed() && ! empty($slug);
-        $hasNonChangedCustomSlug = ! $this->slugIsBasedOnTitle() && ! empty($slug);
+        $hasNonChangedCustomSlug = ! $slugGeneratedFromCallable && ! $this->slugIsBasedOnTitle() && ! empty($slug);
 
         if ($hasCustomSlug || $hasNonChangedCustomSlug) {
             $slugString = $slug;


### PR DESCRIPTION
A _translatable_ slug wouldn't update when it was generated from a callback.