### PR TITLE
Add extra scope callback option

### DIFF
--- a/README.md
+++ b/README.md
@@ -246,6 +246,18 @@ public function getSlugOptions() : SlugOptions
 }
 ```
 
+If you have a global scope that should be taken into account, you can define this as well with `extraScope`. For example if you have a pages table containing pages of multiple websites and every website has it's own unique slugs.
+
+```php
+public function getSlugOptions() : SlugOptions
+{
+    return SlugOptions::create()
+        ->generateSlugsFrom('name')
+        ->saveSlugsTo('slug')
+        ->extraScope(fn ($builder) => $builder->where('scope_id', $this->scope_id));
+}
+```
+
 ### Integration with laravel-translatable
 
 You can use this package along with [laravel-translatable](https://github.com/spatie/laravel-translatable) to generate a slug for each locale. Instead of using the `HasSlug` trait, you must use the `HasTranslatableSlug` trait, and add the name of the slug field to the `$translatable` array. For slugs that are generated from a single field _or_ multiple fields, you don't have to change anything else.

--- a/src/HasSlug.php
+++ b/src/HasSlug.php
@@ -134,6 +134,10 @@ trait HasSlug
         $query = static::where($this->slugOptions->slugField, $slug)
             ->withoutGlobalScopes();
 
+        if ($this->slugOptions->extraScopeCallback) {
+            $query->where($this->slugOptions->extraScopeCallback);
+        }            
+
         if ($this->exists) {
             $query->where($this->getKeyName(), '!=', $this->getKey());
         }

--- a/src/SlugOptions.php
+++ b/src/SlugOptions.php
@@ -7,6 +7,9 @@ class SlugOptions
     /** @var array|callable */
     public $generateSlugFrom;
 
+    /** @var callable */
+    public $extraScopeCallback;
+
     public string $slugField;
 
     public bool $generateUniqueSlugs = true;
@@ -102,6 +105,13 @@ class SlugOptions
     public function usingLanguage(string $language): self
     {
         $this->slugLanguage = $language;
+
+        return $this;
+    }
+
+    public function extraScope(callable $callbackMethod): self
+    {
+        $this->extraScopeCallback = $callbackMethod;
 
         return $this;
     }

--- a/tests/HasScopeTest.php
+++ b/tests/HasScopeTest.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Spatie\Sluggable\Tests;
+
+class HasScopeTest extends TestCase
+{
+    /** @test */
+    public function it_generates_same_slug_for_each_scope()
+    {
+        $testModel  = ScopeableModel::create(['name' => 'name', 'scope_id' => 1]);
+        $testModel2 = ScopeableModel::create(['name' => 'name', 'scope_id' => 2]);
+
+        $this->assertSame($testModel->slug, $testModel2->slug);
+    }
+
+    /** @test */
+    public function it_generates_different_slug_for_same_scope()
+    {
+        $testModel  = ScopeableModel::create(['name' => 'name', 'scope_id' => 1]);
+        $testModel2 = ScopeableModel::create(['name' => 'name', 'scope_id' => 1]);
+
+        $this->assertNotSame($testModel->slug, $testModel2->slug);
+    }
+}

--- a/tests/ScopeableModel.php
+++ b/tests/ScopeableModel.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Spatie\Sluggable\Tests;
+
+use Illuminate\Database\Eloquent\Model;
+use Spatie\Sluggable\HasSlug;
+use Spatie\Sluggable\SlugOptions;
+
+class ScopeableModel extends Model
+{
+    use HasSlug;
+
+    protected $table = 'scopeable_models';
+
+    protected $guarded = [];
+    public $timestamps = false;
+
+    public $translatable = ['name', 'slug', 'scope_id'];
+
+    public function getSlugOptions(): SlugOptions
+    {
+        return SlugOptions::create()
+            ->generateSlugsFrom('name')
+            ->saveSlugsTo('slug')
+            ->extraScope(fn ($builder) => $builder->where('scope_id', $this->scope_id));
+    }
+}

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -63,6 +63,13 @@ abstract class TestCase extends Orchestra
             $table->text('non_translatable_field')->nullable();
             $table->text('slug')->nullable();
         });
+
+        $app['db']->connection()->getSchemaBuilder()->create('scopeable_models', function (Blueprint $table) {
+            $table->increments('id');
+            $table->text('name')->nullable();
+            $table->text('slug')->nullable();
+            $table->unsignedInteger('scope_id')->nullable();
+        });
     }
 
     protected function initializeDirectory(string $directory)


### PR DESCRIPTION
When a table has an extra scope that needs to be accounted for, you can add this scope to the SlugOptions. For instance, when you have a table `pages` which contains multiple pages for multiple sites. Every site could have it's own unique slugs. Therefor you want to be able to add an extra scope.

You can now do this by adding to the Page model:
```
 public function getSlugOptions() : SlugOptions
    {
        $options = SlugOptions::create()
            ->generateSlugsFrom('title')
            ->saveSlugsTo('slug')
            ->extraScope(fn ($builder) => $builder->where('site_id', $this->site_id));

        return $options;
    }
```
