### PR TITLE
Adds test case for replicate method

### DIFF
--- a/tests/HasSlugTest.php
+++ b/tests/HasSlugTest.php
@@ -320,4 +320,37 @@ class HasSlugTest extends TestCase
             $this->assertEquals("this-is-a-test-{$i}", $model->url);
         }
     }
+
+    /** @test */
+    public function it_will_save_a_unique_slug_by_default_when_replicating_a_model()
+    {
+        $model = TestModel::create(['name' => 'this is a test']);
+
+        $replica = $model->replicate();
+        $replica->save();
+
+        $this->assertEquals('this-is-a-test', $model->url);
+        $this->assertEquals('this-is-a-test-1', $replica->url);
+    }
+
+
+    /** @test */
+    public function it_will_save_a_unique_slug_when_replicating_a_model_that_does_not_generates_slugs_on_update()
+    {
+        $model = new class() extends TestModel {
+            public function getSlugOptions(): SlugOptions
+            {
+                return parent::getSlugOptions()->doNotGenerateSlugsOnUpdate();
+            }
+        };
+
+        $model->name = 'this is a test';
+        $model->save();
+
+        $replica = $model->replicate();
+        $replica->save();
+
+        $this->assertEquals('this-is-a-test', $model->url);
+        $this->assertEquals('this-is-a-test-1', $replica->url);
+    }
 }


### PR DESCRIPTION
Adds a test that covers the case mentioned in #199 

There is no issue with the `replicate()` method as a new slug is generated when the `save()` method is called.

Same thing happens when a new model is created, the slug will be generated when the `save()` method is called.

No changes, no bugs found.

Closes #199 

#hacktoberfest -ing