### PR TITLE
Fix Deprecation: currentSlug is null

### DIFF
--- a/src/HasTranslatableSlug.php
+++ b/src/HasTranslatableSlug.php
@@ -63,7 +63,7 @@ trait HasTranslatableSlug
 
         $slugGeneratedFromCallable = is_callable($this->slugOptions->generateSlugFrom);
         $hasCustomSlug = $this->hasCustomSlugBeenUsed() && ! empty($slug);
-        $hasNonChangedCustomSlug = ! $slugGeneratedFromCallable && ! $this->slugIsBasedOnTitle() && ! empty($slug);
+        $hasNonChangedCustomSlug = ! $slugGeneratedFromCallable && ! empty($slug) && ! $this->slugIsBasedOnTitle();
 
         if ($hasCustomSlug || $hasNonChangedCustomSlug) {
             $slugString = $slug;


### PR DESCRIPTION
Check for slug before checking if slugIsBasedOnTitle()

Fixes https://github.com/spatie/laravel-sluggable/issues/217