### PR TITLE
Add support for spatie/laravel-translatable:^6.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
     },
     "require-dev": {
         "orchestra/testbench": "^6.23|^7.0",
-        "spatie/laravel-translatable": "^5.0",
+        "spatie/laravel-translatable": "^5.0|^6.0",
         "phpunit/phpunit": "^9.5.1"
     },
     "autoload": {


### PR DESCRIPTION
This PR adds support for the latest version of ```spatie/laravel-translatable```