### PR TITLE
Add ability to skip the slug generation by a condition

### DIFF
--- a/README.md
+++ b/README.md
@@ -212,6 +212,20 @@ $model->slug = 'my-custom-url';
 $model->save(); //slug is now "my-custom-url";
 ```
 
+## Prevents slugs from being generated on some conditions
+
+If you don't want to create the slug when the model has a state, you can use the `skipGenerateWhen` function.
+
+```php
+public function getSlugOptions() : SlugOptions
+{
+    return SlugOptions::create()
+        ->generateSlugsFrom('name')
+        ->saveSlugsTo('slug')
+        ->skipGenerateWhen(fn () => $this->state === 'draft');
+}
+```
+
 ### Prevent slugs from being generated on creation
 
 If you don't want to create the slug when the model is initially created you can set use the `doNotGenerateSlugsOnCreate()` function.

--- a/src/HasSlug.php
+++ b/src/HasSlug.php
@@ -27,6 +27,10 @@ trait HasSlug
     {
         $this->slugOptions = $this->getSlugOptions();
 
+        if ($this->slugOptions->skipGenerate) {
+            return;
+        }
+
         if (! $this->slugOptions->generateSlugsOnCreate) {
             return;
         }
@@ -43,6 +47,10 @@ trait HasSlug
     protected function generateSlugOnUpdate(): void
     {
         $this->slugOptions = $this->getSlugOptions();
+
+        if ($this->slugOptions->skipGenerate) {
+            return;
+        }
 
         if (! $this->slugOptions->generateSlugsOnUpdate) {
             return;

--- a/src/SlugOptions.php
+++ b/src/SlugOptions.php
@@ -16,6 +16,8 @@ class SlugOptions
 
     public int $maximumLength = 250;
 
+    public bool $skipGenerate = false;
+
     public bool $generateSlugsOnCreate = true;
 
     public bool $generateSlugsOnUpdate = true;
@@ -70,6 +72,13 @@ class SlugOptions
     public function slugsShouldBeNoLongerThan(int $maximumLength): self
     {
         $this->maximumLength = $maximumLength;
+
+        return $this;
+    }
+
+    public function skipGenerateWhen(callable $callable): self
+    {
+        $this->skipGenerate = $callable() === true;
 
         return $this;
     }

--- a/tests/HasSlugTest.php
+++ b/tests/HasSlugTest.php
@@ -156,8 +156,32 @@ it('can handle duplicates when overwriting a slug', function () {
     expect($model->url)->toEqual('this-is-an-other-1');
 });
 
+it('has a method that prevents a slug being generated on condition', function () {
+    $model = new class () extends TestModel {
+        public function getSlugOptions(): SlugOptions
+        {
+            return parent::getSlugOptions()
+                ->skipGenerateWhen(fn () => $this->name === 'Skip me');
+        }
+    };
 
-it('has an method that prevents a slug being generated on creation', function () {
+    $model->name = 'Skip me';
+    $model->save();
+
+    expect($model->url)->toBeNull();
+
+    $model->other_field = 'Spatie';
+    $model->save();
+
+    expect($model->url)->toBeNull();
+
+    $model->name = 'this is a test';
+    $model->save();
+
+    expect($model->url)->toEqual('this-is-a-test');
+});
+
+it('has a method that prevents a slug being generated on creation', function () {
     $model = new class () extends TestModel {
         public function getSlugOptions(): SlugOptions
         {
@@ -171,7 +195,7 @@ it('has an method that prevents a slug being generated on creation', function ()
     expect($model->url)->toBeNull();
 });
 
-it('has an method that prevents a slug being generated on update', function () {
+it('has a method that prevents a slug being generated on update', function () {
     $model = new class () extends TestModel {
         public function getSlugOptions(): SlugOptions
         {

--- a/tests/HasSlugTest.php
+++ b/tests/HasSlugTest.php
@@ -161,11 +161,11 @@ it('has a method that prevents a slug being generated on condition', function ()
         public function getSlugOptions(): SlugOptions
         {
             return parent::getSlugOptions()
-                ->skipGenerateWhen(fn () => $this->name === 'Skip me');
+                ->skipGenerateWhen(fn () => $this->name === 'draft');
         }
     };
 
-    $model->name = 'Skip me';
+    $model->name = 'draft';
     $model->save();
 
     expect($model->url)->toBeNull();
@@ -175,10 +175,10 @@ it('has a method that prevents a slug being generated on condition', function ()
 
     expect($model->url)->toBeNull();
 
-    $model->name = 'this is a test';
+    $model->name = 'this is not a draft';
     $model->save();
 
-    expect($model->url)->toEqual('this-is-a-test');
+    expect($model->url)->toEqual('this-is-not-a-draft');
 });
 
 it('has a method that prevents a slug being generated on creation', function () {


### PR DESCRIPTION
Hi dears.

The PR adds the ability to skip the slug generation by a condition like so:
```php
class Page extends Model
{
        HasSlug;

        public function getSlugOptions(): SlugOptions
        {
            return parent::getSlugOptions()
                ->skipGenerateWhen(fn () => $this->status === 'draft');
        }
}
```