### PR TITLE
Shareable Slugable

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,11 +18,12 @@
     "require": {
         "php": "^8.0",
         "illuminate/database": "^8.0|^9.0",
-        "illuminate/support": "^8.0|^9.0"
+        "illuminate/support": "^8.0|^9.0",
+        "spatie/laravel-package-tools": "^1.9.2"
     },
     "require-dev": {
         "orchestra/testbench": "^6.23|^7.0",
-        "spatie/laravel-translatable": "^5.0|^6.0",      
+        "spatie/laravel-translatable": "^5.0|^6.0",
         "pestphp/pest": "^1.20"
     },
     "autoload": {
@@ -38,6 +39,13 @@
     "scripts": {
         "test": "vendor/bin/pest",
         "format": "vendor/bin/php-cs-fixer fix --allow-risky=yes"
+    },
+    "extra": {
+        "laravel": {
+            "providers": [
+                "Spatie\\Sluggable\\SluggableServiceProvider"
+            ]
+        }
     },
     "minimum-stability": "dev",
     "prefer-stable": true

--- a/database/migrations/create_slug_table.php.stub
+++ b/database/migrations/create_slug_table.php.stub
@@ -1,0 +1,26 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class CreateSlugTable extends Migration
+{
+    public function up()
+    {
+        Schema::create('slugs', function (Blueprint $table) {
+            $table->bigIncrements('id');
+            $table->string('name');
+            $table->string('locale');
+            $table->morphs('sluggable');
+
+            $table->unique(['name', 'sluggable_type']); // Unique slugs per model type
+            $table->unique(['locale', 'sluggable_type', 'sluggable_id']); // Unique locale per model id
+        });
+    }
+
+    public function down()
+    {
+        Schema::drop('slugs');
+    }
+}

--- a/src/HasShareableTranslatableSlug.php
+++ b/src/HasShareableTranslatableSlug.php
@@ -126,7 +126,7 @@ trait HasShareableTranslatableSlug
         }
 
         return Collection::wrap($generateSlugFrom)
-            ->filter(fn ($fieldName) => $this->isTranslatableAttribute($fieldName))
+            ->filter(fn($fieldName) => $this->isTranslatableAttribute($fieldName))
             ->flatMap(function (string $fieldName) {
                 return Collection::wrap($this->getTranslations($fieldName))
                     ->diff($this->getOriginal($fieldName))
@@ -194,7 +194,7 @@ trait HasShareableTranslatableSlug
     {
         $query = Slug::where('name', $slug)
             ->where('sluggable_type', static::class)
-            ->whereNot('sluggable_id', $this->getKey());
+            ->where('sluggable_id', '!=', $this->getKey()); // Can be replaced by whereNot in Laravel 9.3.0+
 
         if ($this->slugOptions->extraScopeCallback) {
             $query->where($this->slugOptions->extraScopeCallback);

--- a/src/HasShareableTranslatableSlug.php
+++ b/src/HasShareableTranslatableSlug.php
@@ -124,7 +124,7 @@ trait HasShareableTranslatableSlug
         }
 
         return Collection::wrap($generateSlugFrom)
-            ->filter(fn($fieldName) => $this->isTranslatableAttribute($fieldName))
+            ->filter(fn ($fieldName) => $this->isTranslatableAttribute($fieldName))
             ->flatMap(function (string $fieldName) {
                 return Collection::wrap($this->getTranslations($fieldName))
                     ->diff($this->getOriginal($fieldName))

--- a/src/HasShareableTranslatableSlug.php
+++ b/src/HasShareableTranslatableSlug.php
@@ -1,0 +1,213 @@
+<?php
+
+namespace Spatie\Sluggable;
+
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\MorphMany;
+use Illuminate\Database\Eloquent\Relations\Relation;
+use Illuminate\Support\Collection;
+use Spatie\Sluggable\Models\Slug;
+
+trait HasShareableTranslatableSlug
+{
+    use HasTranslatableSlug;
+
+    protected Collection $overrideSlugs;
+
+    protected function initializeHasShareableTranslatableSlug()
+    {
+        $this->overrideSlugs = Collection::empty();
+    }
+
+    protected static function bootHasSlug(): void
+    {
+        static::created(function (Model $model) {
+            $model->createOverrideSlugs();
+            $model->generateSlugOnCreate();
+            $model->clearOverrideSlugs();
+        });
+
+        static::updated(function (Model $model) {
+            $model->createOverrideSlugs();
+            $model->generateSlugOnUpdate();
+            $model->clearOverrideSlugs();
+        });
+
+        static::deleted(function (Model $model) {
+            $model->clearSlugs();
+        });
+    }
+
+    protected function setSlugField(string $value): void
+    {
+        $this->setOverrideSlug($value);
+        unset($this->slug);
+    }
+
+    protected function setOverrideSlug(string $slug): void
+    {
+        $this->overrideSlugs->put($this->getLocale(), $slug);
+    }
+
+    protected function clearSlugs(): void
+    {
+        if (method_exists($this, 'trashed') && $this->trashed()) {
+            return;
+        }
+
+        $this->slugs()->delete();
+    }
+
+    protected function isSlugEmpty(): bool
+    {
+        if ($this->exists) {
+            return $this->slugs()->exists();
+        }
+
+        return $this->overrideSlugs->isNotEmpty();
+    }
+
+    protected function createOverrideSlugs(): void
+    {
+        $this->overrideSlugs->each(function (string $name, string $locale) {
+            $this->slugs()->create([
+                'name' => $name,
+                'locale' => $locale
+            ]);
+        });
+    }
+
+    protected function clearOverrideSlugs(): void
+    {
+        $this->overrideSlugs = Collection::empty();
+    }
+
+    protected function addSlug(): void
+    {
+        $this->ensureValidSlugOptions();
+
+        $this->deleteForgottenSlugs();
+
+        $this->getModifiedLocalesForSlug()->unique()->each(function ($locale) {
+
+            $this->withLocale($locale, function () use ($locale) {
+
+                $slug = $this->generateNonUniqueSlug();
+
+                if ($this->slugOptions->generateUniqueSlugs) {
+                    $slug = $this->makeSlugUnique($slug);
+                }
+
+                $this->updateOrCreateSlug($slug);
+            });
+        });
+    }
+
+    protected function deleteForgottenSlugs()
+    {
+        $locales = $this->getLocalesForSlug();
+
+        $this->slugs()
+            ->whereNotIn('locale', $locales)
+            ->each(function (Slug $slug) {
+                $slug->delete();
+            });
+    }
+
+    protected function getModifiedLocalesForSlug(): Collection
+    {
+        $generateSlugFrom = $this->slugOptions->generateSlugFrom;
+
+        if (is_callable($generateSlugFrom)) {
+            // returns a collection of locales that were given to the SlugOptions object
+            // when it was instantiated with the 'createWithLocales' method.
+            return Collection::make($this->slugOptions->translatableLocales);
+        }
+
+        return Collection::wrap($generateSlugFrom)
+            ->filter(fn ($fieldName) => $this->isTranslatableAttribute($fieldName))
+            ->flatMap(function (string $fieldName) {
+                return Collection::wrap($this->getTranslations($fieldName))
+                    ->diff($this->getOriginal($fieldName))
+                    ->keys();
+            });
+    }
+
+    protected function updateOrCreateSlug(string $name): void
+    {
+        $this->slugs()->updateOrCreate(
+            ['locale' => $this->getLocale()],
+            ['name' => $name]
+        );
+    }
+
+    protected function getTranslatedSlug(string $locale): string|null
+    {
+        return $this->slugs()->where('locale', $locale)->first()?->name;
+    }
+
+    protected function hasCustomSlugBeenUsed(): bool
+    {
+        return false;
+    }
+
+    public function slugs(): MorphMany
+    {
+        return $this->morphMany(Slug::class, 'sluggable');
+    }
+
+    public function getSlug(string $locale = null): string|null
+    {
+        if ($this->overrideSlugs->contains($locale)) {
+            return $this->overrideSlugs->get($locale);
+        }
+
+        return $this->slugs()
+            ->where('locale', $locale ?? $this->getLocale())
+            ->first()?->name;
+    }
+
+    public function setSlug(string $value, string $locale = null)
+    {
+        $this->slugOptions = $this->getSlugOptions();
+        $slug = $this->generateNonUniqueSlugFromString($value);
+
+        $locale = $locale ?? $this->getLocale();
+
+        $this->withLocale($locale, function () use ($slug) {
+
+            if ($this->slugOptions->generateUniqueSlugs) {
+                $slug = $this->makeSlugUnique($slug);
+            }
+
+            if (!$this->exists) {
+                $this->setOverrideSlug($slug);
+                return;
+            }
+
+            $this->updateOrCreateSlug($slug);
+        });
+    }
+
+    protected function otherRecordExistsWithSlug(string $slug): bool
+    {
+        $query = Slug::where('name', $slug)
+            ->where('sluggable_type', static::class)
+            ->whereNot('sluggable_id', $this->getKey());
+
+        if ($this->slugOptions->extraScopeCallback) {
+            $query->where($this->slugOptions->extraScopeCallback);
+        }
+
+        return $query->exists();
+    }
+
+    protected function queryModel($query, $value, $field): Builder|Relation
+    {
+        return $query->whereHas('slugs', function ($query) use ($value) {
+            $query->where('name', $value);
+        });
+    }
+
+}

--- a/src/HasSlug.php
+++ b/src/HasSlug.php
@@ -181,7 +181,7 @@ trait HasSlug
      * Helper function to handle multi-bytes strings if the module mb_substr is present,
      * default to substr otherwise.
      */
-    protected function generateSubstring($slugSourceString)
+    protected function generateSubstring($slugSourceString): string
     {
         if (function_exists('mb_substr')) {
             return mb_substr($slugSourceString, 0, $this->slugOptions->maximumLength);

--- a/src/HasSlug.php
+++ b/src/HasSlug.php
@@ -35,10 +35,8 @@ trait HasSlug
             return;
         }
 
-        if ($this->slugOptions->preventOverwrite) {
-            if ($this->{$this->slugOptions->slugField} !== null) {
-                return;
-            }
+        if ($this->slugOptions->preventOverwrite && $this->isSlugFieldEmpty()) {
+            return;
         }
 
         $this->addSlug();
@@ -56,13 +54,16 @@ trait HasSlug
             return;
         }
 
-        if ($this->slugOptions->preventOverwrite) {
-            if ($this->{$this->slugOptions->slugField} !== null) {
-                return;
-            }
+        if ($this->slugOptions->preventOverwrite && $this->isSlugFieldEmpty()) {
+            return;
         }
 
         $this->addSlug();
+    }
+
+    protected function isSlugFieldEmpty(): bool
+    {
+        return $this->{$this->slugOptions->slugField} !== null;
     }
 
     public function generateSlug(): void
@@ -95,7 +96,12 @@ trait HasSlug
             return $this->$slugField;
         }
 
-        return Str::slug($this->getSlugSourceString(), $this->slugOptions->slugSeparator, $this->slugOptions->slugLanguage);
+        return $this->generateNonUniqueSlugFromString($this->getSlugSourceString());
+    }
+
+    protected function generateNonUniqueSlugFromString(string $slugString): string
+    {
+        return Str::slug($slugString, $this->slugOptions->slugSeparator, $this->slugOptions->slugLanguage);
     }
 
     protected function hasCustomSlugBeenUsed(): bool

--- a/src/HasSlug.php
+++ b/src/HasSlug.php
@@ -187,7 +187,7 @@ trait HasSlug
      * Helper function to handle multi-bytes strings if the module mb_substr is present,
      * default to substr otherwise.
      */
-    protected function generateSubstring($slugSourceString): string
+    protected function generateSubstring($slugSourceString)
     {
         if (function_exists('mb_substr')) {
             return mb_substr($slugSourceString, 0, $this->slugOptions->maximumLength);

--- a/src/Models/Slug.php
+++ b/src/Models/Slug.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Spatie\Sluggable\Models;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\MorphTo;
+
+/**
+ *
+ * Slug
+ *
+ * @property string locale
+ * @property string name
+ * @method Illuminate\Database\Eloquent\Builder|Slug whereLocale($value)
+ * @method Illuminate\Database\Eloquent\Builder|Slug whereName($value)
+ */
+
+class Slug extends Model
+{
+    protected $fillable = ['name', 'locale'];
+    public $timestamps = false;
+
+    public function parent(): MorphTo
+    {
+        return $this->morphTo();
+    }
+}

--- a/src/SluggableServiceProvider.php
+++ b/src/SluggableServiceProvider.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Spatie\Sluggable;
+
+use Spatie\LaravelPackageTools\PackageServiceProvider;
+use Spatie\LaravelPackageTools\Package;
+
+class SluggableServiceProvider extends PackageServiceProvider
+{
+    public function configurePackage(Package $package): void
+    {
+        $package
+            ->name('laravel-sluggable')
+            ->hasMigration('create_slug_table');
+    }
+}

--- a/tests/HasShareableTranslatableSlugTest.php
+++ b/tests/HasShareableTranslatableSlugTest.php
@@ -1,0 +1,366 @@
+<?php
+
+use Illuminate\Routing\Middleware\SubstituteBindings;
+use Illuminate\Support\Facades\Route;
+use Spatie\Sluggable\Models\Slug;
+use Spatie\Sluggable\SlugOptions;
+use Spatie\Sluggable\Tests\TestSupport\TestModel;
+use Spatie\Sluggable\Tests\TestSupport\TranslatableShareableModel;
+use Spatie\Sluggable\Tests\TestSupport\TranslatableShareableModelSoftDeletes;
+
+beforeEach(function () {
+    $this->testModel = new TranslatableShareableModel();
+});
+
+it('generates a slug for each translation', function () {
+
+    $this->testModel->setTranslation('name', 'en', 'Test value EN');
+    $this->testModel->setTranslation('name', 'nl', 'Test value NL');
+
+    $this->testModel->save();
+
+    expect($this->testModel->getSlug())->toBe('test-value-en')
+        ->and($this->testModel->getSlug('nl'))->toBe('test-value-nl');
+});
+
+it('can update one of the translations', function () {
+    $this->testModel->setTranslation('name', 'en', 'Test value EN');
+    $this->testModel->setTranslation('name', 'nl', 'Test value NL');
+    $this->testModel->save();
+
+    $this->testModel->setTranslation('name', 'en', 'Updated value EN');
+    $this->testModel->save();
+
+    expect($this->testModel->getSlug())->toBe('updated-value-en')
+        ->and($this->testModel->getSlug('nl'))->toBe('test-value-nl');
+});
+
+it('can update all translations', function () {
+    $this->testModel->setTranslation('name', 'en', 'Test value EN');
+    $this->testModel->setTranslation('name', 'nl', 'Test value NL');
+    $this->testModel->save();
+
+    $this->testModel->setTranslation('name', 'en', 'Updated value EN');
+    $this->testModel->setTranslation('name', 'nl', 'Updated value NL');
+    $this->testModel->save();
+
+    expect($this->testModel->getSlug())->toBe('updated-value-en')
+        ->and($this->testModel->getSlug('nl'))->toBe('updated-value-nl');
+});
+
+it('can make the slug unique for each language', function () {
+    $this->testModel->setTranslation('name', 'en', 'Test value EN');
+    $this->testModel->setTranslation('name', 'nl', 'Test value NL');
+    $this->testModel->save();
+
+    $secondTestModel = TranslatableShareableModel::create([
+        'name' => [
+            'en' => 'Test value EN',
+            'nl' => 'Test value NL',
+        ],
+    ]);
+
+    expect($secondTestModel->getSlug())->toBe('test-value-en-1')
+        ->and($secondTestModel->getSlug('nl'))->toBe('test-value-nl-1');
+});
+
+it('can generate a slug based on multiple fields', function () {
+    $this->testModel->useSlugOptions(
+        SlugOptions::create()
+            ->generateSlugsFrom(['name', 'other_field'])
+            ->saveSlugsTo('slug')
+    );
+
+    $this->testModel->setTranslation('name', 'en', 'Name EN');
+    $this->testModel->setTranslation('name', 'nl', 'Name NL');
+    $this->testModel->setTranslation('other_field', 'en', 'Other EN');
+    $this->testModel->setTranslation('other_field', 'nl', 'Other NL');
+    $this->testModel->save();
+
+    expect($this->testModel->getSlug())->toBe('name-en-other-en')
+        ->and($this->testModel->getSlug('nl'))->toBe('name-nl-other-nl');
+});
+
+it('handles fields that are not translatable', function () {
+    $this->testModel->useSlugOptions(
+        SlugOptions::create()
+            ->generateSlugsFrom(['name', 'non_translatable_field'])
+            ->saveSlugsTo('slug')
+    );
+
+    $this->testModel->setTranslation('name', 'en', 'Name EN');
+    $this->testModel->setTranslation('name', 'nl', 'Name NL');
+    $this->testModel->non_translatable_field = 'awesome';
+    $this->testModel->save();
+
+    expect($this->testModel->getSlug())->toBe('name-en-awesome')
+        ->and($this->testModel->getSlug('nl'))->toBe('name-nl-awesome');
+});
+
+it('uses the fallback language if one of the fields is not translated', function () {
+    $this->testModel->useSlugOptions(
+        SlugOptions::create()
+            ->generateSlugsFrom(['name', 'other_field'])
+            ->saveSlugsTo('slug')
+    );
+
+    $this->testModel->setTranslation('name', 'en', 'Name EN');
+    $this->testModel->setTranslation('name', 'nl', 'Name NL');
+    $this->testModel->setTranslation('other_field', 'en', 'Other EN');
+    $this->testModel->save();
+
+    expect($this->testModel->getSlug())->toBe('name-en-other-en')
+        ->and($this->testModel->getSlug('nl'))->toBe('name-nl-other-en');
+});
+
+it('can use a callback to generate a slug per language', function () {
+    $this->testModel->useSlugOptions(
+        SlugOptions::createWithLocales(['en', 'nl'])
+            ->generateSlugsFrom(function ($model, $locale) {
+                return implode(' ', [
+                    $model->getTranslation('name', $locale, false),
+                    $model->getTranslation('other_field', $locale, false),
+                ]);
+            })
+            ->saveSlugsTo('slug')
+    );
+
+    $this->testModel->setTranslation('name', 'en', 'Name EN');
+    $this->testModel->setTranslation('name', 'nl', 'Name NL');
+    $this->testModel->setTranslation('other_field', 'en', 'Other EN');
+    $this->testModel->setTranslation('other_field', 'nl', 'Other NL');
+
+    $this->testModel->save();
+
+    expect($this->testModel->getSlug())->toBe('name-en-other-en')
+        ->and($this->testModel->getSlug('nl'))->toBe('name-nl-other-nl');
+});
+
+it('can use a callback to update the slug per language', function () {
+    $this->testModel->useSlugOptions(
+        SlugOptions::createWithLocales(['en', 'nl'])
+            ->generateSlugsFrom(function ($model, $locale) {
+                return implode(' ', [
+                    $model->getTranslation('name', $locale, false),
+                    $model->getTranslation('other_field', $locale, false),
+                ]);
+            })
+            ->saveSlugsTo('slug')
+    );
+
+    $this->testModel->setTranslation('name', 'en', 'Name EN');
+    $this->testModel->setTranslation('name', 'nl', 'Name NL');
+    $this->testModel->setTranslation('other_field', 'en', '1');
+    $this->testModel->setTranslation('other_field', 'nl', '1');
+
+    $this->testModel->save();
+
+    $this->testModel->setTranslation('other_field', 'en', '2');
+    $this->testModel->setTranslation('other_field', 'nl', '2');
+
+    $this->testModel->save();
+
+    expect($this->testModel->getSlug())->toBe('name-en-2')
+        ->and($this->testModel->getSlug('nl'))->toBe('name-nl-2');
+});
+
+it('can handle overwrites when creating a model', function () {
+    $this->testModel->setTranslation('name', 'en', 'Test value EN');
+    $this->testModel->setTranslation('name', 'nl', 'Test value NL');
+
+    $this->testModel->setSlug('updated-value-en', 'en');
+    $this->testModel->setSlug('updated-value-nl', 'nl');
+
+    $this->testModel->save();
+
+    expect($this->testModel->getSlug())->toBe('updated-value-en')
+        ->and($this->testModel->getSlug('nl'))->toBe('updated-value-nl');
+});
+
+it('can handle overwrites when updating a model', function () {
+    $this->testModel->setTranslation('name', 'en', 'Test value EN');
+    $this->testModel->setTranslation('name', 'nl', 'Test value NL');
+    $this->testModel->save();
+
+    $this->testModel->setSlug('updated-value-en', 'en');
+    $this->testModel->setSlug('updated-value-nl', 'nl');
+
+    expect($this->testModel->getSlug())->toBe('updated-value-en')
+        ->and($this->testModel->getSlug('nl'))->toBe('updated-value-nl');
+});
+
+it('can handle overwrites for one item when updating a model', function () {
+    $this->testModel->setTranslation('name', 'en', 'Test value EN');
+    $this->testModel->setTranslation('name', 'nl', 'Test value NL');
+    $this->testModel->save();
+
+    $this->testModel->setSlug( 'updated-value-nl', 'nl');
+
+    expect($this->testModel->getSlug())->toBe('test-value-en')
+        ->and($this->testModel->getSlug('nl'))->toBe('updated-value-nl');
+});
+
+it('can handle overwrites for one item when updating a model with custom slugs', function () {
+    $this->testModel->setTranslation('name', 'en', 'Test value EN');
+    $this->testModel->setTranslation('name', 'nl', 'Test value NL');
+    $this->testModel->setSlug('Test slug NL', 'nl');
+    $this->testModel->setSlug('Test slug EN', 'en');
+    $this->testModel->save();
+
+    $this->testModel->setSlug( 'updated-value-nl', 'nl');
+
+    expect($this->testModel->getSlug())->toBe('test-slug-en')
+        ->and($this->testModel->getSlug('nl'))->toBe('updated-value-nl');
+});
+
+it('can handle duplicates when overwriting a slug', function () {
+    $this->testModel->setTranslation('name', 'en', 'Test value EN');
+    $this->testModel->setTranslation('name', 'nl', 'Test value NL');
+    $this->testModel->save();
+
+    $newModel = new $this->testModel();
+    $newModel->setTranslation('name', 'en', 'Test value 2 EN');
+    $newModel->setTranslation('name', 'nl', 'Test value 2 NL');
+    $newModel->save();
+
+    $newModel->setSlug('test-value-en', 'en');
+    $newModel->setSlug('test-value-nl', 'nl');
+
+    expect($newModel->getSlug())->toBe('test-value-en-1')
+        ->and($newModel->getSlug('nl'))->toBe('test-value-nl-1');
+});
+
+it('can update slug with non unique names', function () {
+    $model1 = new TranslatableShareableModel();
+    $model1->setSlug('Test Value', 'en');
+    $model1->save();
+
+    $model2 = new TranslatableShareableModel();
+    $model2->setSlug('Test Value', 'en');
+    $model2->save();
+
+    $model2->setSlug('Changed Value', 'en');
+
+    expect($model2->getSlug('en'))->toBe('changed-value');
+});
+
+it('can resolve route binding', function () {
+    $model = new TranslatableShareableModel();
+
+    $model->setTranslation('name', 'en', 'Test value EN');
+    $model->setTranslation('name', 'nl', 'Test value NL');
+    $model->save();
+
+    // Test for en locale
+    $result = (new TranslatableShareableModel())->resolveRouteBinding('test-value-en', 'slug');
+
+    expect($result)->not->toBeNull()
+        ->and($result->id)->toEqual($model->id);
+
+    // Test for nl locale
+    app()->setLocale('nl');
+
+    $result = (new TranslatableShareableModel())->resolveRouteBinding('test-value-nl', 'slug');
+
+    expect($result)->not->toBeNull()
+        ->and($result->id)->toEqual($model->id);
+
+    // Test for fr locale - should fail
+    app()->setLocale('fr');
+    $result = (new TranslatableShareableModel())->resolveRouteBinding('updated-value-nl', 'slug');
+
+    expect($result)->toBeNull();
+});
+
+it('can resolve route binding even when soft deletes are on', function () {
+    foreach (range(1, 10) as $i) {
+        $model = new TranslatableShareableModelSoftDeletes();
+        $model->setTranslation('name', 'en', 'Test value EN');
+        $model->setSlug('updated-value-en-' . $i, 'en');
+        $model->save();
+        $model->delete();
+
+        $result = (new TranslatableShareableModelSoftDeletes())->resolveSoftDeletableRouteBinding(
+            'updated-value-en-' . $i,
+            'slug'
+        );
+
+        expect($result)->not->toBeNull()
+            ->and($result->id)->toEqual($model->id);
+    }
+});
+
+it('can bind route model implicit', function () {
+    $model = new TranslatableShareableModel();
+    $model->setTranslation('name', 'en', 'Test value EN');
+    $model->setSlug('updated-value-en', 'en');
+    $model->save();
+
+    Route::get(
+        '/translatable-model/{test:slug}',
+        function (TranslatableShareableModel $test) use ($model) {
+            expect($test)->not->toBeNull()
+                ->and($test->id)->toEqual($model->id);
+        }
+    )->middleware(SubstituteBindings::class);
+
+    $response = $this->get("/translatable-model/updated-value-en");
+
+    $response->assertStatus(200);
+});
+
+it('can bind child route model implicit', function () {
+    $parent = new TestModel();
+    $parent->name = 'parent';
+    $parent->save();
+
+    $model = new TranslatableShareableModel();
+    $model->setTranslation('name', 'en', 'Test value EN');
+    $model->test_model_id = 1;
+    $model->save();
+
+    Route::get(
+        '/test-model/{test_model:url}/translatable-shareable-model/{translatable_shareable_model:slug}/',
+        function (TestModel $testModel, TranslatableShareableModel $translatableShareableModel) use ($parent, $model) {
+            expect($parent)->not->toBeNull()
+                ->and($translatableShareableModel)->not->toBeNull()
+                ->and($parent->id)->toEqual($testModel->id)
+                ->and($model->id)->toEqual($translatableShareableModel->id);
+        }
+    )->middleware(SubstituteBindings::class);
+
+    $response = $this->get("/test-model/parent/translatable-shareable-model/test-value-en");
+
+    $response->assertStatus(200);
+});
+
+it('clears all slugs when model is deleted', function () {
+    $model = new TranslatableShareableModel();
+    $model->setTranslation('name', 'en', 'Test value EN');
+    $model->save();
+    $model->delete();
+
+    expect(Slug::all()->isEmpty())->toBeTrue();
+});
+
+it('deletes slug when translation is deleted', function () {
+    $model = new TranslatableShareableModel();
+    $model->setTranslation('name', 'en', 'Test value EN');
+    $model->setTranslation('name', 'nl', 'Test value NL');
+    $model->save();
+
+    $model->forgetAllTranslations('nl');
+    $model->save();
+
+    expect(Slug::whereLocale('nl')->exists())->not->toBeTrue()
+        ->and(Slug::whereLocale('en')->exists())->toBeTrue();
+});
+
+it('keeps slugs when model is trashed', function () {
+    $model = new TranslatableShareableModelSoftDeletes();
+    $model->setTranslation('name', 'en', 'Test value EN');
+    $model->save();
+    $model->delete();
+
+    expect(Slug::all()->count())->toBe(1);
+});

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -78,6 +78,26 @@ abstract class TestCase extends Orchestra
             $table->text('slug')->nullable();
             $table->unsignedInteger('scope_id')->nullable();
         });
+
+        require_once __DIR__.'/../database/migrations/create_slug_table.php.stub';
+        (new \CreateSlugTable())->up();
+
+        Schema::create('translatable_shareable_models', function (Blueprint $table) {
+            $table->increments('id');
+            $table->text('name')->nullable();
+            $table->text('other_field')->nullable();
+            $table->text('non_translatable_field')->nullable();
+            $table->foreignId('test_model_id')->nullable()->index();
+        });
+
+        Schema::create('translatable_shareable_models_soft_deletes', function (Blueprint $table) {
+            $table->increments('id');
+            $table->text('name')->nullable();
+            $table->text('other_field')->nullable();
+            $table->text('non_translatable_field')->nullable();
+            $table->foreignId('test_model_id')->nullable()->index();
+            $table->softDeletes();
+        });
     }
 
     protected function initializeDirectory(string $directory)

--- a/tests/TestSupport/TestModel.php
+++ b/tests/TestSupport/TestModel.php
@@ -49,4 +49,9 @@ class TestModel extends Model
     {
         return $this->hasMany(TranslatableModel::class);
     }
+
+    public function translatableShareableModels(): HasMany
+    {
+        return $this->hasMany(TranslatableShareableModel::class);
+    }
 }

--- a/tests/TestSupport/TranslatableShareableModel.php
+++ b/tests/TestSupport/TranslatableShareableModel.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace Spatie\Sluggable\Tests\TestSupport;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Spatie\Sluggable\HasShareableTranslatableSlug;
+use Spatie\Sluggable\SlugOptions;
+use Spatie\Translatable\HasTranslations;
+
+class TranslatableShareableModel extends Model
+{
+    use HasTranslations;
+    use HasShareableTranslatableSlug;
+
+    protected $table = 'translatable_shareable_models';
+
+    protected $guarded = [];
+    public $timestamps = false;
+
+    protected array $translatable = ['name', 'other_field'];
+
+    private ?SlugOptions $customSlugOptions = null;
+
+    public function useSlugOptions(SlugOptions $slugOptions)
+    {
+        $this->customSlugOptions = $slugOptions;
+    }
+
+    public function getSlugOptions(): SlugOptions
+    {
+        return $this->customSlugOptions ?: SlugOptions::create()
+            ->generateSlugsFrom('name')
+            ->saveSlugsTo('slug');
+    }
+
+    public function testModel(): BelongsTo
+    {
+        return $this->belongsTo(TestModel::class);
+    }
+}

--- a/tests/TestSupport/TranslatableShareableModelSoftDeletes.php
+++ b/tests/TestSupport/TranslatableShareableModelSoftDeletes.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace Spatie\Sluggable\Tests\TestSupport;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\SoftDeletes;
+use Spatie\Sluggable\HasShareableTranslatableSlug;
+use Spatie\Sluggable\SlugOptions;
+use Spatie\Translatable\HasTranslations;
+
+class TranslatableShareableModelSoftDeletes extends Model
+{
+    use HasTranslations;
+    use HasShareableTranslatableSlug;
+    use SoftDeletes;
+
+    protected $table = 'translatable_shareable_models_soft_deletes';
+
+    protected $guarded = [];
+    public $timestamps = false;
+
+    protected array $translatable = ['name', 'other_field'];
+
+    private ?SlugOptions $customSlugOptions = null;
+
+    public function useSlugOptions(SlugOptions $slugOptions)
+    {
+        $this->customSlugOptions = $slugOptions;
+    }
+
+    public function getSlugOptions(): SlugOptions
+    {
+        return $this->customSlugOptions ?: SlugOptions::create()
+            ->generateSlugsFrom('name')
+            ->saveSlugsTo('slug');
+    }
+
+    public function testModel(): BelongsTo
+    {
+        return $this->belongsTo(TestModel::class);
+    }
+}


### PR DESCRIPTION
# What

Adds possibility to share URLs with localized slugs between different preferred user locales.

# Why 

When sharing a link with a local slug to a person with a different navigator language, 404 is returned even though the model exists with a different locale.
The proposed changes introduce a new database table which stores all translated slugs.
This approach was chosen as querying for JSON values is highly inefficient with large datasets.
With thus change, the developer can now decide, wherever the user should see the model with the intended locale or the user's preferred locale.

# Changes

This PR introduces no BC, but has some changes in the usage of the new trait.
* Some methods in `HasSlug` and `HasTranslateableSlug` have been split up to allow them to be partially overwritten.
* Shareable slugs are now stored in a separate `slugs` table.
* A service provider was added for migration.
* The slugs are automatically changed when `->setSlug` is called.
* Non-unique slugs are not supported
* The access with `$model->slug` is no longer available, as this would require `getAttributeValue` and `setAttribute`to be overwritten. This would conflict with the `Translateable` trait. Any ideas on how to solve this are appreciated!
* The slugs are saved at the `created` and `updated` event, as the model needs to exist in order to save the slug. 
* In case a slug is defined before model creation, the slug is stored locally until the model is created.