### PR TITLE
composer allow-plugins config

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -40,5 +40,10 @@
         "format": "vendor/bin/php-cs-fixer fix --allow-risky=yes"
     },
     "minimum-stability": "dev",
-    "prefer-stable": true
+    "prefer-stable": true,
+    "config": {
+        "allow-plugins": {
+            "pestphp/pest-plugin": true
+        }
+    }
 }


### PR DESCRIPTION
The workflow setup for this project is failing because composer needs to explicitly allow plugins - in this case it's `pestphp/pest`

For example, you can see the job fail on the latest commit to `main` here: https://github.com/spatie/laravel-sluggable/actions/runs/3375599921/jobs/5602390946

When performing `composer install` on a freshly cloned repo you are prompted with this:

<img width="875" alt="Screenshot_20221102_083147" src="https://user-images.githubusercontent.com/6332533/199491206-08d04675-7b0a-4aff-aa95-ea01a2e96308.png">

The fix is to whitelist this plugin in the composer config section.
