### PR TITLE
Add support for dictionary in slugs

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,6 +188,24 @@ public function getSlugOptions() : SlugOptions
 }
 ```
 
+### Handling special characters
+
+To change how characters are replaced by `Str::slug` you may call `dictionary`
+
+```php
+public function getSlugOptions() : SlugOptions
+{
+    return SlugOptions::create()
+        ->generateSlugsFrom('name')
+        ->saveSlugsTo('slug')
+        ->dictionary([
+            '@' => 'at',
+            '$' => 'dollar',
+            '&' => 'and',
+        ]);
+}
+```
+
 ### Setting the slug language
 
 To set the language used by `Str::slug` you may call `usingLanguage`

--- a/src/HasSlug.php
+++ b/src/HasSlug.php
@@ -95,7 +95,7 @@ trait HasSlug
             return $this->$slugField;
         }
 
-        return Str::slug($this->getSlugSourceString(), $this->slugOptions->slugSeparator, $this->slugOptions->slugLanguage);
+        return Str::slug($this->getSlugSourceString(), $this->slugOptions->slugSeparator, $this->slugOptions->slugLanguage, $this->slugOptions->dictionary);
     }
 
     protected function hasCustomSlugBeenUsed(): bool

--- a/src/HasTranslatableSlug.php
+++ b/src/HasTranslatableSlug.php
@@ -71,7 +71,7 @@ trait HasTranslatableSlug
             $slugString = $slug;
         }
 
-        return Str::slug($slugString, $this->slugOptions->slugSeparator, $this->slugOptions->slugLanguage);
+        return Str::slug($slugString, $this->slugOptions->slugSeparator, $this->slugOptions->slugLanguage, $this->slugOptions->dictionary);
     }
 
     protected function getSlugSourceStringFromCallable(): string

--- a/src/SlugOptions.php
+++ b/src/SlugOptions.php
@@ -30,6 +30,8 @@ class SlugOptions
 
     public array $translatableLocales = [];
 
+    public array $dictionary = ['@' => 'at'];
+
     public static function create(): static
     {
         return new static();
@@ -121,6 +123,13 @@ class SlugOptions
     public function extraScope(callable $callbackMethod): self
     {
         $this->extraScopeCallback = $callbackMethod;
+
+        return $this;
+    }
+
+    public function dictionary(array $dictionary): self
+    {
+        $this->dictionary = $dictionary;
 
         return $this;
     }

--- a/tests/HasSlugTest.php
+++ b/tests/HasSlugTest.php
@@ -4,6 +4,7 @@ use Illuminate\Support\Str;
 use Spatie\Sluggable\SlugOptions;
 use Spatie\Sluggable\Tests\TestSupport\TestModel;
 use Spatie\Sluggable\Tests\TestSupport\TestModelSoftDeletes;
+use Spatie\Sluggable\Tests\TestSupport\TestModelWithDictionary;
 
 it('will save a slug when saving a model', function () {
     $model = TestModel::create(['name' => 'this is a test']);
@@ -314,4 +315,18 @@ it('will save a unique slug when replicating a model that does not generates slu
 
     expect($model->url)->toEqual('this-is-a-test');
     expect($replica->url)->toEqual('this-is-a-test-1');
+});
+
+it('will replace characters using a dictionary', function () {
+    $model = new class () extends TestModel {
+        public function getSlugOptions(): SlugOptions
+        {
+            return parent::getSlugOptions()->dictionary(['$' => 'dollar']);
+        }
+    };
+
+    $model->name = '500$ bill';
+    $model->save();
+
+    expect($model->url)->toEqual('500-dollar-bill');
 });

--- a/tests/HasSlugTest.php
+++ b/tests/HasSlugTest.php
@@ -4,7 +4,6 @@ use Illuminate\Support\Str;
 use Spatie\Sluggable\SlugOptions;
 use Spatie\Sluggable\Tests\TestSupport\TestModel;
 use Spatie\Sluggable\Tests\TestSupport\TestModelSoftDeletes;
-use Spatie\Sluggable\Tests\TestSupport\TestModelWithDictionary;
 
 it('will save a slug when saving a model', function () {
     $model = TestModel::create(['name' => 'this is a test']);

--- a/tests/HasTranslatableSlugTest.php
+++ b/tests/HasTranslatableSlugTest.php
@@ -359,3 +359,17 @@ it('can bind child route model implicit', function () {
 
     $response->assertStatus(200);
 });
+
+it('will replace characters using a dictionary', function () {
+    $model = new class () extends TranslatableModel {
+        public function getSlugOptions(): SlugOptions
+        {
+            return parent::getSlugOptions()->dictionary(['$' => 'dollar']);
+        }
+    };
+
+    $model->setTranslation('name', 'en', '500$ bill');
+    $model->save();
+
+    expect($model->slug)->toEqual('500-dollar-bill');
+});


### PR DESCRIPTION
This PR adds support for passing a dictionary to specify how characters should be replaced when making a slug using the Str::slug Laravel helpers [recent addition](https://github.com/laravel/framework/pull/44730). Support for dictionary in the slug helper was added in Laravel 9.38, so this would increase the minimum required version. So this may be better suited for a later major update.

This would allow us to do something like this

``` php
public function getDefaultSlugOptions(): SlugOptions
{
    return SlugOptions::create()
        ->generateSlugsFrom('name')
        ->dictionary(['$' => 'dollar'])
        ->saveSlugsTo('url');
}
```

Resulting in a slug for `500$ bill`being `500-dollar-bill`