### PR TITLE
Normalize composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,12 +1,11 @@
 {
     "name": "spatie/laravel-sluggable",
     "description": "Generate slugs when saving Eloquent models",
+    "license": "MIT",
     "keywords": [
         "spatie",
         "laravel-sluggable"
     ],
-    "homepage": "https://github.com/spatie/laravel-sluggable",
-    "license": "MIT",
     "authors": [
         {
             "name": "Freek Van der Herten",
@@ -15,6 +14,7 @@
             "role": "Developer"
         }
     ],
+    "homepage": "https://github.com/spatie/laravel-sluggable",
     "require": {
         "php": "^8.0",
         "illuminate/database": "^8.0|^9.0",
@@ -22,9 +22,11 @@
     },
     "require-dev": {
         "orchestra/testbench": "^6.23|^7.0",
-        "spatie/laravel-translatable": "^5.0|^6.0",      
-        "pestphp/pest": "^1.20"
+        "pestphp/pest": "^1.20",
+        "spatie/laravel-translatable": "^5.0|^6.0"
     },
+    "minimum-stability": "dev",
+    "prefer-stable": true,
     "autoload": {
         "psr-4": {
             "Spatie\\Sluggable\\": "src"
@@ -35,15 +37,13 @@
             "Spatie\\Sluggable\\Tests\\": "tests"
         }
     },
-    "scripts": {
-        "test": "vendor/bin/pest",
-        "format": "vendor/bin/php-cs-fixer fix --allow-risky=yes"
-    },
-    "minimum-stability": "dev",
-    "prefer-stable": true,
     "config": {
         "allow-plugins": {
             "pestphp/pest-plugin": true
         }
+    },
+    "scripts": {
+        "format": "vendor/bin/php-cs-fixer fix --allow-risky=yes",
+        "test": "vendor/bin/pest"
     }
 }


### PR DESCRIPTION
This PR normalizes composer.json using [ergebnis/composer-normalize](https://github.com/ergebnis/composer-normalize) to ensure that the composer.json file is valid and consistent according to the [Composer schema](https://getcomposer.org/schema.json).

_id:composer-normalization/v1_