### PR TITLE
feat: add findBySlug alias

### DIFF
--- a/README.md
+++ b/README.md
@@ -409,6 +409,16 @@ class YourEloquentModel extends Model
 }
 ```
 
+### Find models by slug
+
+For convenience, you can use the alias `findBySlug` to retrieve a model. The query will compare against the field passed to `saveSlugsTo` when defining the `SlugOptions`.
+
+```php
+$model = Article::findBySlug('my-article');
+```
+
+`findBySlug` also accepts a second parameter `$columns` just like the default Eloquent `find` method.
+
 
 ## Changelog
 

--- a/src/HasSlug.php
+++ b/src/HasSlug.php
@@ -5,6 +5,7 @@ namespace Spatie\Sluggable;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Str;
 use Spatie\Sluggable\Exceptions\InvalidOption;
+use Spatie\Sluggable\Tests\TestSupport\TranslatableModel;
 
 trait HasSlug
 {
@@ -188,5 +189,17 @@ trait HasSlug
         }
 
         return substr($slugSourceString, 0, $this->slugOptions->maximumLength);
+    }
+
+    public static function findBySlug(string $slug, array $columns = ['*'])
+    {
+        $modelInstance = new static;
+        $field = $modelInstance->getSlugOptions()->slugField;
+
+        $field = in_array(HasTranslatableSlug::class, class_uses_recursive(static::class))
+            ? "{$field}->{$modelInstance->getLocale()}"
+            : $field;
+
+        return static::where($field, $slug)->first($columns);
     }
 }

--- a/tests/HasSlugTest.php
+++ b/tests/HasSlugTest.php
@@ -333,3 +333,19 @@ it('can generate slug suffix starting from given number', function () {
     expect($model->url)->toEqual('this-is-a-test');
     expect($replica->url)->toEqual('this-is-a-test-2');
 });
+
+it('can find models using findBySlug alias', function () {
+    $model = new class () extends TestModel {
+        public function getSlugOptions(): SlugOptions
+        {
+            return parent::getSlugOptions()->saveSlugsTo('url');
+        }
+    };
+
+    $model->name = 'my custom url';
+    $model->save();
+
+    $savedModel = $model::findBySlug('my-custom-url');
+
+    expect($savedModel->id)->toEqual($model->id);
+});

--- a/tests/HasTranslatableSlugTest.php
+++ b/tests/HasTranslatableSlugTest.php
@@ -359,3 +359,19 @@ it('can bind child route model implicit', function () {
 
     $response->assertStatus(200);
 });
+
+it('can find models using findBySlug alias', function () {
+    $model = new class () extends TranslatableModel {
+        public function getSlugOptions(): SlugOptions
+        {
+            return parent::getSlugOptions()->saveSlugsTo('slug');
+        }
+    };
+
+    $model->name = 'my custom url';
+    $model->save();
+
+    $savedModel = $model::findBySlug('my-custom-url');
+
+    expect($savedModel->id)->toEqual($model->id);
+});


### PR DESCRIPTION
I have added a convenient method `findBySlug` to retrieve a model by the `saveSlugsTo` field configured in the `SlugOptions`. Works on both `HasSlug` and `HasTranslatableSlug`.