### PR TITLE
Add findBySlugOrFail

### DIFF
--- a/src/HasSlug.php
+++ b/src/HasSlug.php
@@ -201,4 +201,16 @@ trait HasSlug
 
         return static::where($field, $slug)->first($columns);
     }
+
+    public static function findBySlugOrFail(string $slug, array $columns = ['*'])
+    {
+        $modelInstance = new static();
+        $field = $modelInstance->getSlugOptions()->slugField;
+
+        $field = in_array(HasTranslatableSlug::class, class_uses_recursive(static::class))
+            ? "{$field}->{$modelInstance->getLocale()}"
+            : $field;
+
+        return static::where($field, $slug)->firstOrFail($columns);
+    }
 }

--- a/tests/HasSlugTest.php
+++ b/tests/HasSlugTest.php
@@ -349,3 +349,19 @@ it('can find models using findBySlug alias', function () {
 
     expect($savedModel->id)->toEqual($model->id);
 });
+
+it('can find models using findBySlugOrFail alias', function () {
+    $model = new class () extends TestModel {
+        public function getSlugOptions(): SlugOptions
+        {
+            return parent::getSlugOptions()->saveSlugsTo('url');
+        }
+    };
+
+    $model->name = 'my custom url';
+    $model->save();
+
+    $savedModel = $model::findBySlugOrFail('my-custom-url');
+
+    expect($savedModel->id)->toEqual($model->id);
+});

--- a/tests/HasTranslatableSlugTest.php
+++ b/tests/HasTranslatableSlugTest.php
@@ -375,3 +375,19 @@ it('can find models using findBySlug alias', function () {
 
     expect($savedModel->id)->toEqual($model->id);
 });
+
+it('can find models using findBySlugOrFail alias', function () {
+    $model = new class () extends TranslatableModel {
+        public function getSlugOptions(): SlugOptions
+        {
+            return parent::getSlugOptions()->saveSlugsTo('slug');
+        }
+    };
+
+    $model->name = 'my custom url';
+    $model->save();
+
+    $savedModel = $model::findBySlugOrFail('my-custom-url');
+
+    expect($savedModel->id)->toEqual($model->id);
+});


### PR DESCRIPTION
Since this PR https://github.com/spatie/laravel-sluggable/pull/256 has been merged, I think it would be useful to add `findBySlugOrFail` as well.

It really helps to streamline your sources, as you don't need to create the method yourself, and Laravel basically uses the same approach (firstOrFail, findOrFail, createOrFail, etc.).

Thanks. :)