### PR TITLE
Add findBySlugOr() method with callback functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -423,13 +423,14 @@ $model = Article::findBySlug('my-article');
 For convenience, you can use the alias `findBySlugOr` to retrieve a model. The query will compare against the field passed to `saveSlugsTo` when defining the `SlugOptions`. If the model does not exist, the callable will be executed and the result will be returned.
 
 ```php
-$model = Article::findBySlugOr('my-article', function () {
+$model = Article::findBySlugOr('my-article', ['*'], function () {
     return Article::create(['name' => 'my-article']);
 });
 
 // or
-$model = Article::findBySlugOr('my-article', fn () => throw new \Exception('Article not found'));
+$model = Article::findBySlugOr('my-article', ['*'],fn () => throw new \Exception('Article not found'));
 ```
+
 
 ## Changelog
 

--- a/README.md
+++ b/README.md
@@ -419,6 +419,17 @@ $model = Article::findBySlug('my-article');
 
 `findBySlug` also accepts a second parameter `$columns` just like the default Eloquent `find` method.
 
+### Find models by slug or
+For convenience, you can use the alias `findBySlugOr` to retrieve a model. The query will compare against the field passed to `saveSlugsTo` when defining the `SlugOptions`. If the model does not exist, the callable will be executed and the result will be returned.
+
+```php
+$model = Article::findBySlugOr('my-article', function () {
+    return Article::create(['name' => 'my-article']);
+});
+
+// or
+$model = Article::findBySlugOr('my-article', fn () => throw new \Exception('Article not found'));
+```
 
 ## Changelog
 

--- a/src/Exceptions/InvalidOption.php
+++ b/src/Exceptions/InvalidOption.php
@@ -20,4 +20,9 @@ class InvalidOption extends Exception
     {
         return new static('Maximum length should be greater than zero');
     }
+
+    public static function missingCallback(): static
+    {
+        return new static('Could not determine which callback should be used');
+    }
 }

--- a/src/HasSlug.php
+++ b/src/HasSlug.php
@@ -201,4 +201,19 @@ trait HasSlug
 
         return static::where($field, $slug)->first($columns);
     }
+
+    public static function findBySlugOr(string $slug, array $columns = ['*'], ?callable $callback = null)
+    {
+        if (!is_callable($callback) && $callback !== null) {
+            throw InvalidOption::missingCallback();
+        }
+        
+        $result = static::findBySlug($slug, $columns);
+
+        if (!$result && is_callable($callback)) {
+            return $callback($slug);
+        }
+
+        return $result;
+    }
 }

--- a/tests/HasSlugTest.php
+++ b/tests/HasSlugTest.php
@@ -349,3 +349,22 @@ it('can find models using findBySlug alias', function () {
 
     expect($savedModel->id)->toEqual($model->id);
 });
+
+it('can use a callable using findBySlugOr alias', function () {
+    $model = new class () extends TestModel {
+        public function getSlugOptions(): SlugOptions
+        {
+            return parent::getSlugOptions()
+                ->saveSlugsTo('url');
+        }
+    };
+
+    $model->name = 'my custom url';
+    $model->save();
+
+    $savedModel = $model::findBySlugOr('my-custom-url1', ['*'], function () {
+        return 'not found';
+    });
+
+    expect($savedModel)->toEqual('not found');
+});


### PR DESCRIPTION
### PR Description:
This pull request adds the `findBySlugOr()` method to the `HasSlug` trait, providing a new feature that allows finding a model by its slug or executing a callback if the slug is not found.

### Changes Made:
- Added the findBySlugOr() method to the HasSlug trait.
- Implemented the callback functionality to execute custom logic when the slug is not found.
- Added a static method missingCallback exception to be thrown when a callback is missing

```php 
$slug = 'some-slug';

// Try to find a model with the given slug 'some-slug'.
// If not found, execute the callback and return its result.
$foundModel = Model::findBySlugOr($slug, ['*'], function ($slug) {
    // Your custom logic here, for example, create a new model with the given slug.
    $newModel = new Model(['slug' => $slug, 'name' => 'New Model']);
    $newModel->save();
    return $newModel;
});
```

### Testing
  - [x] Included tests to verify that the callback is executed correctly when the slug is not found.

