### PR TITLE
Changing reference to Laravel docs without Laravel version

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ class CreateYourEloquentModelTable extends Migration
 
 ### Using slugs in routes
 
-To use the generated slug in routes, remember to use Laravel's [implicit route model binding](https://laravel.com/docs/5.8/routing#implicit-binding):
+To use the generated slug in routes, remember to use Laravel's [implicit route model binding](https://laravel.com/docs/routing#implicit-binding):
 
 ```php
 namespace App;
@@ -371,8 +371,8 @@ class YourEloquentModel extends Model
 
 #### Implicit route model binding
 
-You can also use Laravels [implicit route model binding](https://laravel.com/docs/8.x/routing#implicit-binding) inside your controller to automatically resolve the model. To use this feature, make sure that the slug column matches the `routeNameKey`.  
-Currently, only some database types support JSON operations. Further information about which databases support JSON can be found in the [Laravel docs](https://laravel.com/docs/8.x/queries#json-where-clauses).
+You can also use Laravels [implicit route model binding](https://laravel.com/docs/routing#implicit-binding) inside your controller to automatically resolve the model. To use this feature, make sure that the slug column matches the `routeNameKey`.  
+Currently, only some database types support JSON operations. Further information about which databases support JSON can be found in the [Laravel docs](https://laravel.com/docs/queries#json-where-clauses).
 
 ```php
 namespace App;


### PR DESCRIPTION
Changing reference to Laravel docs without Laravel version, so they redirect to the documentation of the latest version