### PR TITLE
Add Fallback Locale and Additional Query Support to `findBySlug`

### DIFF
--- a/src/HasSlug.php
+++ b/src/HasSlug.php
@@ -190,15 +190,31 @@ trait HasSlug
         return substr($slugSourceString, 0, $this->slugOptions->maximumLength);
     }
 
-    public static function findBySlug(string $slug, array $columns = ['*'])
+    public static function findBySlug(string $slug, array $columns = ['*'], callable $additionalQuery = null)
     {
         $modelInstance = new static();
         $field = $modelInstance->getSlugOptions()->slugField;
 
-        $field = in_array(HasTranslatableSlug::class, class_uses_recursive(static::class))
-            ? "{$field}->{$modelInstance->getLocale()}"
-            : $field;
+        $currentLocale = $modelInstance->getLocale();
+        $fallbackLocale = config('app.fallback_locale');
 
-        return static::where($field, $slug)->first($columns);
+        $query = static::query();
+
+        if (in_array(HasTranslatableSlug::class, class_uses_recursive(static::class))) {
+            $currentField = "{$field}->{$currentLocale}";
+            $fallbackField = "{$field}->{$fallbackLocale}";
+
+            $query->where($currentField, $slug);
+
+            $query->orWhere($fallbackField, $slug);
+        } else {
+            $query->where($field, $slug);
+        }
+
+        if (is_callable($additionalQuery)) {
+            $additionalQuery($query);
+        }
+
+        return $query->first($columns);
     }
 }

--- a/src/HasSlug.php
+++ b/src/HasSlug.php
@@ -195,12 +195,12 @@ trait HasSlug
         $modelInstance = new static();
         $field = $modelInstance->getSlugOptions()->slugField;
 
-        $currentLocale = $modelInstance->getLocale();
-        $fallbackLocale = config('app.fallback_locale');
-
         $query = static::query();
 
         if (in_array(HasTranslatableSlug::class, class_uses_recursive(static::class))) {
+            $currentLocale = $modelInstance->getLocale();
+            $fallbackLocale = config('app.fallback_locale');
+
             $currentField = "{$field}->{$currentLocale}";
             $fallbackField = "{$field}->{$fallbackLocale}";
 


### PR DESCRIPTION
Add Fallback Locale and Additional Query Support to `findBySlug`

This PR enhances the `findBySlug` method in the `HasSlug`  trait by introducing two key features:

1. Fallback Locale Support
 - If the model uses the `HasTranslatableSlug`  trait, the method now checks for a matching slug in both the current locale and the fallback locale (defined in the application's `fallback_locale` configuration).
2. Additional Query Customization
 - A new `$additionalQuery` parameter has been added, allowing developers to pass a callable to customize the query further.

Example Use Case:
```
$model = MyModel::findBySlug('example-slug', ['id', 'name'], function ($query) {
    $query->where('status', 'active');
});
```