### PR TITLE
Fix query for translatable slug

### DIFF
--- a/src/HasSlug.php
+++ b/src/HasSlug.php
@@ -190,7 +190,7 @@ trait HasSlug
         return substr($slugSourceString, 0, $this->slugOptions->maximumLength);
     }
 
-    public static function findBySlug(string $slug, array $columns = ['*'], callable $additionalQuery = null)
+    public static function findBySlug(string $slug, array $columns = ['*'], ?callable $additionalQuery = null)
     {
         $modelInstance = new static();
         $field = $modelInstance->getSlugOptions()->slugField;
@@ -204,9 +204,7 @@ trait HasSlug
             $currentField = "{$field}->{$currentLocale}";
             $fallbackField = "{$field}->{$fallbackLocale}";
 
-            $query->where($currentField, $slug);
-
-            $query->orWhere($fallbackField, $slug);
+            $query->where(fn ($query) => $query->where($currentField, $slug)->orWhere($fallbackField, $slug));
         } else {
             $query->where($field, $slug);
         }


### PR DESCRIPTION
It was an error with `$additionalQuery` for translatable slug

e.g. example it was before fix:

```sql
select * from `posts` where json_unquote(json_extract(`slug`, '$."nl"')) = '/' or json_unquote(json_extract(`slug`, '$."en"')) = '/' and `team_id` = 3
```

correct SQL should be
```sql
select * from `posts` where (json_unquote(json_extract(`slug`, '$."nl"')) = '/' or json_unquote(json_extract(`slug`, '$."en"')) = '/') and `team_id` = 3
```


it was `WHERE statement1 or statement2 and additionalStatement3` instead of `WHERE (statement1 or statement2) and additionalStatement3`

@freekmurze 