### PR TITLE
Add explicit nullable type for additionalQuery parameter

### DIFF
--- a/src/HasSlug.php
+++ b/src/HasSlug.php
@@ -190,7 +190,7 @@ trait HasSlug
         return substr($slugSourceString, 0, $this->slugOptions->maximumLength);
     }
 
-    public static function findBySlug(string $slug, array $columns = ['*'], callable $additionalQuery = null)
+    public static function findBySlug(string $slug, array $columns = ['*'], ?callable $additionalQuery = null)
     {
         $modelInstance = new static();
         $field = $modelInstance->getSlugOptions()->slugField;


### PR DESCRIPTION
This PR addresses a deprecation warning in PHP 8.4 related to implicit nullable parameters.

## Changes
- Updated the type declaration of `$additionalQuery` parameter in `findBySlug` method from `callable $additionalQuery = null` to `?callable $additionalQuery = null`