### PR TITLE
Also account for HasManyThrough / BelongsToMany relations

### DIFF
--- a/src/HasTranslatableSlug.php
+++ b/src/HasTranslatableSlug.php
@@ -126,11 +126,16 @@ trait HasTranslatableSlug
     public function resolveRouteBindingQuery($query, $value, $field = null): Builder|Relation
     {
         $field = $field ?? $this->getRouteKeyName();
+        $slug = $this->getSlugOptions()->slugField;
 
-        if ($field !== $this->getSlugOptions()->slugField) {
-            return parent::resolveRouteBindingQuery($query, $value, $field);
+        if (str_contains($field, '.') && str_ends_with($field, ".{$slug}")) {
+            return $query->where("{$field}->{$this->getLocale()}", $value);
         }
 
-        return $query->where("{$field}->{$this->getLocale()}", $value);
+        if ($field === $slug) {
+            return $query->where("{$field}->{$this->getLocale()}", $value);
+        }
+
+        return parent::resolveRouteBindingQuery($query, $value, $field);
     }
 }

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -78,6 +78,25 @@ abstract class TestCase extends Orchestra
             $table->text('slug')->nullable();
             $table->unsignedInteger('scope_id')->nullable();
         });
+
+        Schema::create('categories', function (Blueprint $table) {
+            $table->id();
+            $table->text('name')->nullable();
+            $table->text('slug')->nullable();
+        });
+
+        Schema::create('projects', function (Blueprint $table) {
+            $table->id();
+            $table->text('name')->nullable();
+            $table->text('slug')->nullable();
+        });
+
+        Schema::create('category_project', function (Blueprint $table) {
+            $table->unsignedBigInteger('category_id');
+            $table->unsignedBigInteger('project_id');
+
+            $table->primary(['category_id', 'project_id']);
+        });
     }
 
     protected function initializeDirectory(string $directory)

--- a/tests/TestSupport/Category.php
+++ b/tests/TestSupport/Category.php
@@ -1,0 +1,36 @@
+<?php declare(strict_types=1);
+
+namespace Spatie\Sluggable\Tests\TestSupport;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsToMany;
+use Spatie\Sluggable\HasTranslatableSlug;
+use Spatie\Sluggable\SlugOptions;
+use Spatie\Translatable\HasTranslations;
+
+class Category extends Model
+{
+    use HasTranslations;
+    use HasTranslatableSlug;
+
+    protected $guarded = [];
+
+    protected $table = 'categories';
+
+    public $timestamps = false;
+
+    protected array $translatable = ['name', 'slug'];
+
+    public function getSlugOptions(): SlugOptions
+    {
+        return SlugOptions::create()
+            ->generateSlugsFrom('name')
+            ->saveSlugsTo('slug');
+    }
+
+    public function projects(): BelongsToMany
+    {
+        return $this->belongsToMany(Project::class);
+    }
+}
+

--- a/tests/TestSupport/Category.php
+++ b/tests/TestSupport/Category.php
@@ -1,4 +1,4 @@
-<?php declare(strict_types=1);
+<?php
 
 namespace Spatie\Sluggable\Tests\TestSupport;
 

--- a/tests/TestSupport/Project.php
+++ b/tests/TestSupport/Project.php
@@ -1,0 +1,37 @@
+<?php declare(strict_types=1);
+
+namespace Spatie\Sluggable\Tests\TestSupport;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\BelongsToMany;
+use Spatie\Sluggable\HasTranslatableSlug;
+use Spatie\Sluggable\SlugOptions;
+use Spatie\Translatable\HasTranslations;
+
+class Project extends Model
+{
+    use HasTranslations;
+    use HasTranslatableSlug;
+
+    protected $guarded = [];
+
+    protected $table = 'projects';
+
+    public $timestamps = false;
+
+    protected array $translatable = ['name', 'slug'];
+
+    public function getSlugOptions(): SlugOptions
+    {
+        return SlugOptions::create()
+            ->generateSlugsFrom('name')
+            ->saveSlugsTo('slug');
+    }
+
+    public function categories(): BelongsToMany
+    {
+        return $this->belongsToMany(Category::class);
+    }
+}
+

--- a/tests/TestSupport/Project.php
+++ b/tests/TestSupport/Project.php
@@ -1,4 +1,4 @@
-<?php declare(strict_types=1);
+<?php
 
 namespace Spatie\Sluggable\Tests\TestSupport;
 


### PR DESCRIPTION
Hey! 👋

There is one edge case that's currently missing in `HasTranslatableSlug::resolveRouteBindingQuery`:
The resolution of child (`HasManyThrough` / `BelongsToMany`) translatable, sluggable fields that are also scoped to the parent.

This PR aims to fix exactly that which I ran into today! Laravel first qualifies the column names when the relation is of type `HasManyThrough` / `BelongsToMany`, so that's why the additional dot-checking is also required.

I'm fully aware that I flipped the script here and am first checking for the happy cases, but the inverse became harder to read. I **_tried_** sticking to the rules of Front Line PHP, but this reads much better IMHO. 😅

Thank you for the awesome packages!