### PR TITLE
Change self-healing redirect from 301 to 308

### DIFF
--- a/docs/basic-usage/getting-started.md
+++ b/docs/basic-usage/getting-started.md
@@ -64,7 +64,7 @@ $post->slug; // "hello-universe"
 
 This step is optional. Skip it if you don't need slugs in your URLs, or if your slugs genuinely never change after creation (see [Self-healing URLs](/docs/laravel-sluggable/v4/basic-usage/self-healing-urls#when-you-dont-need-self-healing) for plain `{post:slug}` binding).
 
-Most user-editable content (blog posts, articles, products, documentation pages, events) eventually gets renamed, and a renamed slug breaks every existing link unless you opt into self-healing URLs. With self-healing enabled the route key becomes `{slug}-{id}`, the primary key drives the lookup, and a stale slug `301`-redirects to the canonical URL instead of returning a `404`.
+Most user-editable content (blog posts, articles, products, documentation pages, events) eventually gets renamed, and a renamed slug breaks every existing link unless you opt into self-healing URLs. With self-healing enabled the route key becomes `{slug}-{id}`, the primary key drives the lookup, and a stale slug `308`-redirects to the canonical URL instead of returning a `404`.
 
 To follow along, add `selfHealing: true` to the attribute on the `Post` model from step 1 and add `use HasSlug;` to the class. The trait is required because self-healing has to override `getRouteKey()` and `resolveRouteBinding()`.
 

--- a/docs/basic-usage/self-healing-urls.md
+++ b/docs/basic-usage/self-healing-urls.md
@@ -5,7 +5,7 @@ weight: 5
 
 Say you publish a blog post titled "Hello World". Its URL is `/posts/hello-world`. A few days later you realise the title should have been "Hello Universe", so you update it. The slug regenerates to `hello-universe` and the URL becomes `/posts/hello-universe`. Every search engine result, every shared link, every bookmark pointing at `/posts/hello-world` now returns `404`.
 
-Self-healing URLs fix this. The route key becomes `{slug}-{id}`. The slug part can change without breaking lookups, because the primary key still resolves the model. Stale slugs trigger a `301` redirect to the canonical URL.
+Self-healing URLs fix this. The route key becomes `{slug}-{id}`. The slug part can change without breaking lookups, because the primary key still resolves the model. Stale slugs trigger a `308` redirect to the canonical URL.
 
 ## Enabling
 
@@ -57,7 +57,7 @@ Route::get('/posts/{post}', fn (Post $post) => $post);
 | Incoming path | Result |
 | --- | --- |
 | `/posts/hello-world-5` | `200 OK` with the resolved model. |
-| `/posts/outdated-slug-5` | `301 Moved Permanently` to `/posts/hello-world-5`. |
+| `/posts/outdated-slug-5` | `308 Permanent Redirect` to `/posts/hello-world-5`. |
 | `/posts/hello-world-99` | `404 Not Found` when id `99` does not exist. |
 | `/posts/hello-world` | `404 Not Found`, no identifier in the URL. |
 
@@ -97,7 +97,7 @@ SlugOptions::create()
 
 ## Customizing the redirect
 
-When an incoming URL's slug is stale, the package throws a `Spatie\Sluggable\Exceptions\StaleSelfHealingUrl` exception. Its `render()` method delegates to the `SelfHealingManager`, which by default returns a `301` redirect to the canonical URL.
+When an incoming URL's slug is stale, the package throws a `Spatie\Sluggable\Exceptions\StaleSelfHealingUrl` exception. Its `render()` method delegates to the `SelfHealingManager`, which by default returns a `308` redirect to the canonical URL.
 
 Register a closure through the `SelfHealing` facade in a service provider's `boot()` method. The closure receives the resolved model, the stale route key, and the incoming request, and returns whatever response you want.
 
@@ -122,7 +122,7 @@ class AppServiceProvider extends ServiceProvider
 
 Use cases include:
 
-- Returning a `302` redirect instead of `301`.
+- Returning a `302` redirect instead of `308`.
 - Rendering an "old link" notification before redirecting.
 - Logging the stale access for analytics.
 - Refusing to redirect based on request state.
@@ -137,7 +137,7 @@ When someone visits `/posts/hello-world-5`, the package splits the URL at the la
 
 Now imagine you rename the post to "Hello Universe". The slug in the database becomes `hello-universe`, but the old link `/posts/hello-world-5` is still floating around on Twitter, in Google's index, and in somebody's bookmarks.
 
-When that old link hits your app, the package again pulls `5` off the end and loads the post. This time the slug in the URL does not match the post's current slug, so the package sends back a `301` redirect to `/posts/hello-universe-5`. The visitor (or the search engine crawler) follows the redirect and lands on the canonical URL.
+When that old link hits your app, the package again pulls `5` off the end and loads the post. This time the slug in the URL does not match the post's current slug, so the package sends back a `308` redirect to `/posts/hello-universe-5`. The visitor (or the search engine crawler) follows the redirect and lands on the canonical URL.
 
 ### No database writes
 

--- a/docs/basic-usage/self-healing-urls.md
+++ b/docs/basic-usage/self-healing-urls.md
@@ -116,7 +116,7 @@ class AppServiceProvider extends ServiceProvider
     public function boot(): void
     {
         SelfHealing::onStaleSelfHealingUrl(function (Model $model, string $staleRouteKey, Request $request) {
-            return redirect()->route('posts.show', $model, status: 302);
+            return redirect()->route('posts.show', $model, status: 307);
         });
     }
 }
@@ -124,7 +124,7 @@ class AppServiceProvider extends ServiceProvider
 
 Use cases include:
 
-- Returning a `302` redirect instead of `308`.
+- Returning a `307` temporary redirect instead of the permanent `308`.
 - Rendering an "old link" notification before redirecting.
 - Logging the stale access for analytics.
 - Refusing to redirect based on request state.

--- a/docs/basic-usage/self-healing-urls.md
+++ b/docs/basic-usage/self-healing-urls.md
@@ -61,6 +61,8 @@ Route::get('/posts/{post}', fn (Post $post) => $post);
 | `/posts/hello-world-99` | `404 Not Found` when id `99` does not exist. |
 | `/posts/hello-world` | `404 Not Found`, no identifier in the URL. |
 
+The redirect uses `308` rather than the more familiar `301` because `308` preserves the request method when followed. A stale `PUT`, `PATCH`, or `DELETE` to a self-healing URL still arrives at the canonical route as the same verb. With `301`, clients are allowed to rewrite the method to `GET`, which would turn the request into a `405 Method Not Allowed` on resource routes. Search engines treat both statuses the same for ranking, so SEO is unaffected. To return something else, see [Customizing the redirect](#customizing-the-redirect) below.
+
 ## Translatable slugs
 
 `HasTranslatableSlug` supports self-healing as well. The route key uses the slug for the current locale.

--- a/docs/introduction.md
+++ b/docs/introduction.md
@@ -30,6 +30,6 @@ On top of generation, this package also ships:
 
 ## Self-healing URLs at a glance
 
-Bookmarks, search results, and shared links keep working when a slug changes. Enable `selfHealing` on the attribute (or the slug options) and the route key becomes `{slug}-{id}`. The primary key resolves the model, the slug just rides along, and stale URLs `301`-redirect to the canonical one.
+Bookmarks, search results, and shared links keep working when a slug changes. Enable `selfHealing` on the attribute (or the slug options) and the route key becomes `{slug}-{id}`. The primary key resolves the model, the slug just rides along, and stale URLs `308`-redirect to the canonical one.
 
 Read the full story in [Self-healing URLs](/docs/laravel-sluggable/v4/basic-usage/self-healing-urls).

--- a/docs/laravel-boost-skill.md
+++ b/docs/laravel-boost-skill.md
@@ -19,7 +19,7 @@ The skill activates when a query mentions slugs, permalinks, the `HasSlug` trait
 - Generating the migration for a slug column, including the `nullable` then unique backfill pattern and the JSON column requirement for translatable slugs.
 - Configuring separator, length, language, uniqueness behavior, and scope.
 - Wiring implicit route binding through the slug column.
-- Enabling self-healing URLs, customizing the separator, and overriding the `301` redirect through the `SelfHealing` facade.
+- Enabling self-healing URLs, customizing the separator, and overriding the `308` redirect through the `SelfHealing` facade.
 - Swapping the default action classes via `config/sluggable.php`.
 
 The full skill content lives at [`resources/boost/skills/sluggable-development/SKILL.md`](https://github.com/spatie/laravel-sluggable/blob/main/resources/boost/skills/sluggable-development/SKILL.md) in the package repository.

--- a/docs/upgrading.md
+++ b/docs/upgrading.md
@@ -55,6 +55,12 @@ Array-style callables (`[$obj, 'method']`) and string callables (`'my_function'`
 
 `HasTranslatableSlug` still keeps its own `$slugOptions` field because it iterates per locale.
 
+## Self-healing redirects are now `308` instead of `301`
+
+The default response for a stale self-healing URL is now `308 Permanent Redirect`, replacing `301 Moved Permanently`. Both convey "permanent" semantics to search engines, but `308` preserves the request method when followed, so `PUT`/`PATCH`/`DELETE` requests to a stale URL no longer silently degrade to `GET` and return `405 Method Not Allowed`.
+
+Update any code that asserts on the specific status code (tests, middleware, monitoring). The behavior of a custom handler registered through `SelfHealing::onStaleSelfHealingUrl()` is unchanged.
+
 ## Renamed: `Sluggable` facade is now `SelfHealing`
 
 The facade for registering the stale-URL handler was renamed to clarify that it only customizes self-healing behavior.

--- a/resources/boost/skills/sluggable-development/SKILL.md
+++ b/resources/boost/skills/sluggable-development/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: sluggable-development
-description: "Use this skill when making a field on an Eloquent model sluggable, generating the migration for a slug column, switching an existing model to self-healing URLs, or resolving a model from its slug in a route. Trigger whenever the request mentions slugs, permalinks, the spatie/laravel-sluggable package, the HasSlug trait, the HasTranslatableSlug trait, the #[Sluggable] attribute, SlugOptions, findBySlug, self-healing URLs, or stale slug redirects in a Laravel project. Covers: choosing between the attribute and the trait, generating unique slugs across create and update, configuring separator/length/language/scope/uniqueness, preventing slug overwrites, scoping uniqueness with a closure, handling translatable slugs via spatie/laravel-translatable, route model binding through the slug column, building {slug}-{id} route keys with selfHealing(), customizing the 301 redirect through the Sluggable facade, overriding the default actions via config/sluggable.php. Do not use for generating URL-safe strings without persisting them, for signed URLs, or for Laravel's built-in Str::slug helper when the result is not stored on a model."
+description: "Use this skill when making a field on an Eloquent model sluggable, generating the migration for a slug column, switching an existing model to self-healing URLs, or resolving a model from its slug in a route. Trigger whenever the request mentions slugs, permalinks, the spatie/laravel-sluggable package, the HasSlug trait, the HasTranslatableSlug trait, the #[Sluggable] attribute, SlugOptions, findBySlug, self-healing URLs, or stale slug redirects in a Laravel project. Covers: choosing between the attribute and the trait, generating unique slugs across create and update, configuring separator/length/language/scope/uniqueness, preventing slug overwrites, scoping uniqueness with a closure, handling translatable slugs via spatie/laravel-translatable, route model binding through the slug column, building {slug}-{id} route keys with selfHealing(), customizing the 308 redirect through the Sluggable facade, overriding the default actions via config/sluggable.php. Do not use for generating URL-safe strings without persisting them, for signed URLs, or for Laravel's built-in Str::slug helper when the result is not stored on a model."
 license: MIT
 metadata:
   author: spatie
@@ -154,7 +154,7 @@ Post::findBySlug('my-post', ['*'], fn ($query) => $query->where('published', tru
 
 ## Self-healing URLs
 
-A self-healing URL combines the slug with the primary key (`hello-world-5`). The slug portion can change freely without breaking existing links: stale slugs trigger a `301` redirect to the canonical URL, missing identifiers return `404`. The feature requires the trait because it overrides `getRouteKey()` and `resolveRouteBinding()`.
+A self-healing URL combines the slug with the primary key (`hello-world-5`). The slug portion can change freely without breaking existing links: stale slugs trigger a `308` redirect to the canonical URL, missing identifiers return `404`. The feature requires the trait because it overrides `getRouteKey()` and `resolveRouteBinding()`.
 
 ```php
 public function getSlugOptions(): SlugOptions
@@ -171,7 +171,7 @@ $post = Post::create(['title' => 'Hello World']);
 $post->getRouteKey(); // "hello-world-5"
 
 // GET /posts/hello-world-5   → 200 OK
-// GET /posts/outdated-slug-5 → 301 redirect to /posts/hello-world-5
+// GET /posts/outdated-slug-5 → 308 redirect to /posts/hello-world-5
 // GET /posts/hello-world-99  → 404 when id 99 does not exist
 ```
 
@@ -197,7 +197,7 @@ SelfHealing::onStaleSelfHealingUrl(function (Model $model, string $staleRouteKey
 });
 ```
 
-The default behavior is a `301` redirect to the canonical URL.
+The default behavior is a `308` redirect to the canonical URL.
 
 ## Translatable slugs
 
@@ -248,7 +248,7 @@ return [
 
 1. Create a model and assert the slug column is populated: `expect($post->slug)->toBe('expected-slug');`.
 2. Update the source column and confirm the slug either updates (default) or stays (with `onUpdate: false` / `doNotGenerateSlugsOnUpdate()`).
-3. Hit the route with a stale slug and assert a `301` redirect to the canonical URL when using self-healing.
+3. Hit the route with a stale slug and assert a `308` redirect to the canonical URL when using self-healing.
 4. Run `php artisan migrate` and confirm the slug column exists with the correct type (`string` or `json` for translatable).
 
 ## Common pitfalls

--- a/src/SelfHealingManager.php
+++ b/src/SelfHealingManager.php
@@ -37,6 +37,6 @@ class SelfHealingManager
             $request->fullUrl(),
         );
 
-        return redirect($canonicalUrl, 301);
+        return redirect($canonicalUrl, 308);
     }
 }

--- a/tests/SelfHealingUrlsTest.php
+++ b/tests/SelfHealingUrlsTest.php
@@ -73,7 +73,7 @@ it('respects a custom separator', function () {
     expect($resolved->id)->toBe($model->id);
 });
 
-it('redirects with a 301 when an implicit route binding encounters a stale slug', function () {
+it('redirects with a 308 when an implicit route binding encounters a stale slug', function () {
     $model = SelfHealingModel::create(['name' => 'Fresh Title']);
 
     Route::get('/posts/{post}', fn (SelfHealingModel $post) => $post->name)
@@ -81,8 +81,24 @@ it('redirects with a 301 when an implicit route binding encounters a stale slug'
 
     $response = $this->get("/posts/old-slug-{$model->id}");
 
-    $response->assertStatus(301);
+    $response->assertStatus(308);
     $response->assertRedirect("/posts/fresh-title-{$model->id}");
+});
+
+it('redirects a POST request with a 308 so the method is preserved', function () {
+    $model = SelfHealingModel::create(['name' => 'Fresh Title']);
+
+    Route::post('/posts/{post}', fn (SelfHealingModel $post) => $post->name)
+        ->middleware(SubstituteBindings::class);
+
+    $redirect = $this->post("/posts/old-slug-{$model->id}");
+    $redirect->assertStatus(308);
+    $redirect->assertRedirect("/posts/fresh-title-{$model->id}");
+
+    // Follow as POST to verify the method is preserved (GET would return 405)
+    $this->post($redirect->headers->get('Location'))
+        ->assertStatus(200)
+        ->assertSee('Fresh Title');
 });
 
 it('responds with 200 when the URL is already canonical', function () {
@@ -147,7 +163,7 @@ it('redirects stale translatable URLs to the current locale canonical URL', func
 
     $response = $this->get("/posts/stale-english-{$model->id}");
 
-    $response->assertStatus(301);
+    $response->assertStatus(308);
     $response->assertRedirect("/posts/fresh-english-{$model->id}");
 });
 

--- a/tests/SelfHealingUrlsTest.php
+++ b/tests/SelfHealingUrlsTest.php
@@ -85,20 +85,16 @@ it('redirects with a 308 when an implicit route binding encounters a stale slug'
     $response->assertRedirect("/posts/fresh-title-{$model->id}");
 });
 
-it('redirects a POST request with a 308 so the method is preserved', function () {
+it('responds to a POST with a 308 status', function () {
     $model = SelfHealingModel::create(['name' => 'Fresh Title']);
 
     Route::post('/posts/{post}', fn (SelfHealingModel $post) => $post->name)
         ->middleware(SubstituteBindings::class);
 
-    $redirect = $this->post("/posts/old-slug-{$model->id}");
-    $redirect->assertStatus(308);
-    $redirect->assertRedirect("/posts/fresh-title-{$model->id}");
+    $response = $this->post("/posts/old-slug-{$model->id}");
 
-    // Follow as POST to verify the method is preserved (GET would return 405)
-    $this->post($redirect->headers->get('Location'))
-        ->assertStatus(200)
-        ->assertSee('Fresh Title');
+    $response->assertStatus(308);
+    $response->assertRedirect("/posts/fresh-title-{$model->id}");
 });
 
 it('responds with 200 when the URL is already canonical', function () {


### PR DESCRIPTION
## What

Changes the default self-healing slug redirect status from `301 Moved Permanently` to `308 Permanent Redirect`.

## Why

A `301` redirect causes browsers and HTTP clients to convert the request method to `GET`. This breaks POST requests that use route model binding with a stale slug — the redirect is followed as a GET, which returns a `405 Method Not Allowed` instead of landing on the correct route.

A `308` is the permanent-redirect equivalent that **preserves the original HTTP method**, so POST (and other non-GET) requests continue to work correctly after following the redirect.

## Changes

- `SelfHealingManager`: `301` → `308`
- Tests: updated existing assertions + added a new test that POSTs to a stale slug URL, asserts a 308, then POSTs to the canonical URL and asserts a 200 (proving the method is preserved — a GET would return 405)
- Docs: all `301` references updated to `308`