### PR TITLE
Add getLocalizedRouteKey method to HasTranslatableSlug

### DIFF
--- a/docs/translatable-slugs.md
+++ b/docs/translatable-slugs.md
@@ -68,10 +68,10 @@ $article = Article::findBySlug('my-article');
 
 ## Getting the route key for a specific locale
 
-Use `getLocalizedRouteKey()` to retrieve the route key for a given locale without changing the model's active locale permanently.
+Use `getLocalizedRouteKey()` to retrieve the route key for a given locale without permanently changing the model's active locale.
 
 ```php
-$article->getLocalizedRouteKey('nl'); // returns the route key for the 'nl' locale
+$article->getLocalizedRouteKey('nl'); // "nederlandse-titel-5"
 ```
 
-The method temporarily sets the model locale inside a `try/finally` block, guaranteeing the original locale is always restored afterwards.
+The method swaps in the requested locale, calls `getRouteKey()`, and restores the original locale via `try/finally`, so the model is always left as it was found, including when `getRouteKey()` throws.

--- a/docs/translatable-slugs.md
+++ b/docs/translatable-slugs.md
@@ -65,3 +65,13 @@ $article = Article::findBySlug('my-article');
 ## Self-healing URLs
 
 `selfHealing()` works with the translatable trait. The route key uses the slug for the current locale; stale slugs trigger the same redirect flow described in [Self-healing URLs](/docs/laravel-sluggable/v4/basic-usage/self-healing-urls).
+
+## Getting the route key for a specific locale
+
+Use `getLocalizedRouteKey()` to retrieve the route key for a given locale without changing the model's active locale permanently.
+
+```php
+$article->getLocalizedRouteKey('nl'); // returns the route key for the 'nl' locale
+```
+
+The method temporarily sets the model locale inside a `try/finally` block, guaranteeing the original locale is always restored afterwards.

--- a/src/HasTranslatableSlug.php
+++ b/src/HasTranslatableSlug.php
@@ -196,6 +196,19 @@ trait HasTranslatableSlug
         return (string) ($this->getTranslation($slugField, $this->getLocale(), false) ?? '');
     }
 
+    public function getLocalizedRouteKey(string $locale): mixed
+    {
+        $originalLocale = $this->getLocale();
+
+        try {
+            $this->setLocale($locale);
+
+            return $this->getRouteKey();
+        } finally {
+            $this->setLocale($originalLocale);
+        }
+    }
+
     public static function findBySlug(string $slug, array $columns = ['*'], ?callable $additionalQuery = null): ?Model
     {
         $modelInstance = new static;

--- a/tests/HasTranslatableSlugTest.php
+++ b/tests/HasTranslatableSlugTest.php
@@ -6,6 +6,7 @@ use Spatie\Sluggable\SlugOptions;
 use Spatie\Sluggable\Tests\TestSupport\Category;
 use Spatie\Sluggable\Tests\TestSupport\Project;
 use Spatie\Sluggable\Tests\TestSupport\TestModel;
+use Spatie\Sluggable\Tests\TestSupport\SelfHealingTranslatableModel;
 use Spatie\Sluggable\Tests\TestSupport\TranslatableModel;
 use Spatie\Sluggable\Tests\TestSupport\TranslatableModelSoftDeletes;
 
@@ -467,3 +468,27 @@ it('can resolve related child model when its scoped to the parent model using a 
 
     $response->assertOk();
 });
+
+it('can get the route key for a specific locale', function () {
+    $model = new SelfHealingTranslatableModel;
+    $model->setTranslation('name', 'en', 'Test value EN');
+    $model->setTranslation('name', 'nl', 'Test value NL');
+    $model->save();
+
+    expect($model->getLocalizedRouteKey('en'))->toContain('test-value-en');
+    expect($model->getLocalizedRouteKey('nl'))->toContain('test-value-nl');
+});
+
+it('restores the original locale after getting a localized route key', function () {
+    $model = new SelfHealingTranslatableModel;
+    $model->setTranslation('name', 'en', 'Test value EN');
+    $model->setTranslation('name', 'nl', 'Test value NL');
+    $model->save();
+
+    $model->setLocale('en');
+
+    $model->getLocalizedRouteKey('nl');
+
+    expect($model->getLocale())->toBe('en');
+});
+

--- a/tests/HasTranslatableSlugTest.php
+++ b/tests/HasTranslatableSlugTest.php
@@ -5,8 +5,8 @@ use Illuminate\Support\Facades\Route;
 use Spatie\Sluggable\SlugOptions;
 use Spatie\Sluggable\Tests\TestSupport\Category;
 use Spatie\Sluggable\Tests\TestSupport\Project;
-use Spatie\Sluggable\Tests\TestSupport\TestModel;
 use Spatie\Sluggable\Tests\TestSupport\SelfHealingTranslatableModel;
+use Spatie\Sluggable\Tests\TestSupport\TestModel;
 use Spatie\Sluggable\Tests\TestSupport\TranslatableModel;
 use Spatie\Sluggable\Tests\TestSupport\TranslatableModelSoftDeletes;
 
@@ -475,8 +475,8 @@ it('can get the route key for a specific locale', function () {
     $model->setTranslation('name', 'nl', 'Test value NL');
     $model->save();
 
-    expect($model->getLocalizedRouteKey('en'))->toContain('test-value-en');
-    expect($model->getLocalizedRouteKey('nl'))->toContain('test-value-nl');
+    expect($model->getLocalizedRouteKey('en'))->toBe("test-value-en-{$model->id}");
+    expect($model->getLocalizedRouteKey('nl'))->toBe("test-value-nl-{$model->id}");
 });
 
 it('restores the original locale after getting a localized route key', function () {


### PR DESCRIPTION
## What

Adds a `getLocalizedRouteKey(string $locale)` method to the `HasTranslatableSlug` trait.

## Why

When building multilingual applications, it's useful to retrieve the route key for a specific locale without having to temporarily switch the application or model locale manually.

## How

The method stores the original model locale via `getLocale()`, then sets the requested locale inside a `try/finally` block to guarantee the original locale is always restored via `setLocale()`, even if something goes wrong.

```php
public function getLocalizedRouteKey(string $locale): mixed
{
    $originalLocale = $this->getLocale();

    try {
        $this->setLocale($locale);

        return $this->getRouteKey();
    } finally {
        $this->setLocale($originalLocale);
    }
}
```

Tests are included for correct slug resolution per locale and locale restoration after the call.